### PR TITLE
fix: query failure due to projection, limit, filter

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -130,29 +130,6 @@ public class LanceMetadata
         return ((LanceColumnHandle) columnHandle).getColumnMetadata();
     }
 
-    @Override
-    public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(ConnectorSession session,
-            ConnectorTableHandle handle, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
-    {
-        throw new UnsupportedOperationException("unsupported");
-    }
-
-    @Override
-    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session,
-            ConnectorTableHandle table, long limit)
-    {
-        // TODO: support limit
-        throw new UnsupportedOperationException("unsupported");
-    }
-
-    @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session,
-            ConnectorTableHandle table, Constraint constraint)
-    {
-        // TODO: support limit
-        throw new UnsupportedOperationException("unsupported");
-    }
-
     @VisibleForTesting
     public LanceConfig getLanceConfig()
     {

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnector.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnector.java
@@ -70,4 +70,25 @@ public class TestLanceConnector
                         (3, 6, 9, -3)
                         """);
     }
+
+    @Test
+    public void testProjection()
+    {
+        assertThat(query("SELECT b FROM test_table1"))
+                .matches("VALUES BIGINT '0', 1, 2, 3");
+    }
+
+    @Test
+    public void testFilter()
+    {
+        assertThat(query("SELECT * FROM test_table1 WHERE b = 0"))
+                .matches("VALUES (BIGINT '0', BIGINT '0', BIGINT '0', BIGINT '0')");
+    }
+
+    @Test
+    public void testLimit()
+    {
+        assertThat(query("SELECT * FROM test_table1 LIMIT 100"))
+                .matches("SELECT * FROM test_table1");
+    }
 }


### PR DESCRIPTION
We shouldn't override `apply*` method if the connector doesn't support the pushdown. 

Otherwise, query fails with a following exception:
```
trino:default> SELECT * FROM test_table1 LIMIT 100;
Query 20251004_112536_00002_6n4mi failed: unsupported
java.lang.UnsupportedOperationException: unsupported
	at io.trino.plugin.lance.LanceMetadata.applyLimit(LanceMetadata.java:145)
	at io.trino.tracing.TracingConnectorMetadata.applyLimit(TracingConnectorMetadata.java:1188)
	at io.trino.metadata.MetadataManager.applyLimit(MetadataManager.java:2017)
	at io.trino.tracing.TracingMetadata.applyLimit(TracingMetadata.java:977)
	at io.trino.sql.planner.iterative.rule.PushLimitIntoTableScan.apply(PushLimitIntoTableScan.java:71)
	at io.trino.sql.planner.iterative.rule.PushLimitIntoTableScan.apply(PushLimitIntoTableScan.java:36)
	at io.trino.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:216)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:181)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:144)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:264)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:146)
	at io.trino.sql.planner.iterative.IterativeOptimizer.optimizeAndMarkPlanChanges(IterativeOptimizer.java:129)
	at io.trino.sql.planner.optimizations.AdaptivePlanOptimizer.optimize(AdaptivePlanOptimizer.java:33)
	at io.trino.sql.planner.LogicalPlanner.runOptimizer(LogicalPlanner.java:308)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:272)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:244)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:239)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:503)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:482)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:420)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.trino.$gen.Trino_testversion____20251004_112311_71.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```