### PR TITLE
chore: update lance dependency to v5.0.0-beta.2

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0-beta.13</version>
+            <version>5.0.0-beta.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` in `plugin/trino-lance/pom.xml` from `4.0.0-beta.13` to `5.0.0-beta.2`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.5.2` (matching Lance 5.x Java POM lineage).

## Verification
- `make lint` passed.
- `make compile` passed.

## Upstream Tag
- Triggering tag: `refs/tags/v5.0.0-beta.2`
