### PR TITLE
chore: update lance dependency to v5.0.0-beta.3

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>5.0.0-beta.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -185,12 +184,11 @@ public class LancePageSink
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Credentials have expiration - let Lance refresh via namespace client + table id
                     fragmentWriter = fragmentWriter
                             .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
                 else {
                     // Static credentials - use storage options directly without provider


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `4.0.0` to `5.0.0-beta.3` in `plugin/trino-lance/pom.xml`.
- Update compatible namespace dependencies to match Lance `v5.0.0-beta.3` source POM:
  - `org.lance:lance-namespace-core` -> `0.6.1`
  - `org.lance:lance-namespace-apache-client` -> `0.6.1`
- Adjust `LancePageSink` to use the current Lance Java API for expiring credentials (`namespaceClient` + `tableId`) instead of removed `LanceNamespaceStorageOptionsProvider`.

## Verification
- `make lint` passes.
- `make compile` passes.

## Notes
- Triggering tag: `refs/tags/v5.0.0-beta.3`
- Maven Central currently does not serve `org.lance:lance-core:5.0.0-beta.3`; to run CI checks locally on this runner, I installed the artifact from source tag `v5.0.0-beta.3` into the local Maven repository.
