### PR TITLE
chore: update lance dependency to v5.0.0-beta.4

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>5.0.0-beta.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -184,17 +183,13 @@ public class LancePageSink
             }
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
+                fragmentWriter = fragmentWriter.storageOptions(storageOptions);
+
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Lance 5.x wires storage refresh through namespace client + table ID.
                     fragmentWriter = fragmentWriter
-                            .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
-                }
-                else {
-                    // Static credentials - use storage options directly without provider
-                    fragmentWriter = fragmentWriter.storageOptions(storageOptions);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
             }
 


### PR DESCRIPTION
## Summary
- bump `org.lance:lance-core` to `5.0.0-beta.4` in `plugin/trino-lance/pom.xml`
- align compatible namespace dependencies to `org.lance:lance-namespace-core:0.6.1` and `org.lance:lance-namespace-apache-client:0.6.1`
- update write-path integration for Lance 5.x API (`WriteFragmentBuilder` now uses `namespaceClient(...)` + `tableId(...)` for expiring credential refresh)

## Verification
- `make lint` ✅
- `make compile` ✅

## Triggering tag
- `refs/tags/v5.0.0-beta.4`
