### PR TITLE
chore: update lance dependency to v5.0.0-beta.5

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>5.0.0-beta.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -170,8 +169,6 @@ public class LancePageSink
             log.debug("Using storage options for table %s: %s", tableId, storageOptions);
 
             // Write fragments using Lance API
-            // Use storageOptionsProvider only if credentials have expiration (expires_at_millis)
-            // Otherwise use static storage_options directly
             WriteFragmentBuilder fragmentWriter = Fragment.write()
                     .datasetUri(datasetUri)
                     .allocator(allocator)
@@ -185,12 +182,11 @@ public class LancePageSink
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Credentials have expiration - use namespace client for auto-refresh
                     fragmentWriter = fragmentWriter
                             .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
                 else {
                     // Static credentials - use storage options directly without provider


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `5.0.0-beta.5` in `plugin/trino-lance/pom.xml`.
- Align `org.lance:lance-namespace-core` and `org.lance:lance-namespace-apache-client` to `0.6.1`.
- Update `LancePageSink` to use the `lance-core` 5.0.0-beta.5 API (`namespaceClient`/`tableId`) for credential refresh instead of `LanceNamespaceStorageOptionsProvider`.

## Build Verification
- `make lint` ✅
- `make compile` ✅

## Triggering Tag
- `refs/tags/v5.0.0-beta.5`
