### PR TITLE
chore: update lance dependency to v5.1.0-beta.1

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>5.1.0-beta.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -185,12 +184,11 @@ public class LancePageSink
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Credentials have expiration - configure namespace client for auto-refresh
                     fragmentWriter = fragmentWriter
                             .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
                 else {
                     // Static credentials - use storage options directly without provider


### PR DESCRIPTION
## Summary
- bump `org.lance:lance-core` in `plugin/trino-lance/pom.xml` to `5.1.0-beta.1`
- align namespace dependencies to `0.6.1` based on the `lance-core` dependency lineage
- update `LancePageSink` to the `lance-core` 5.1.0-beta.1 API (`namespaceClient`/`tableId`) for expiring credential handling

## Build Verification
- `make lint` passes
- `make compile` passes

## Triggering Tag
- `refs/tags/v5.1.0-beta.1`
