### PR TITLE
chore: update lance dependency to v6.0.0-beta.3

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>6.0.0-beta.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -170,7 +169,7 @@ public class LancePageSink
             log.debug("Using storage options for table %s: %s", tableId, storageOptions);
 
             // Write fragments using Lance API
-            // Use storageOptionsProvider only if credentials have expiration (expires_at_millis)
+            // Use namespace refresh only if credentials have expiration (expires_at_millis)
             // Otherwise use static storage_options directly
             WriteFragmentBuilder fragmentWriter = Fragment.write()
                     .datasetUri(datasetUri)
@@ -185,12 +184,11 @@ public class LancePageSink
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Credentials have expiration - use namespace/table context for auto-refresh
                     fragmentWriter = fragmentWriter
                             .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
                 else {
                     // Static credentials - use storage options directly without provider


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `6.0.0-beta.3`.
- Update Lance namespace dependencies to `0.6.1`, matching the `lance-core` `refs/tags/v6.0.0-beta.3` source POM.
- Adapt expiring storage-option refresh to the new Lance Core builder API using `namespaceClient(...)` and `tableId(...)`.

Triggering tag: refs/tags/v6.0.0-beta.3

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central returned 404 for `org.lance:lance-core:6.0.0-beta.3` at verification time, so I installed `lance-core` locally from `lance-format/lance` tag `refs/tags/v6.0.0-beta.3` with `./mvnw -DskipTests -Dskip.build.jni=true -Dspotless.skip=true install` before running the checks.
