### PR TITLE
Fix Unhandled type for long: integer error

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.TimeMicroVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -323,8 +324,14 @@ public class LanceArrowToPageScanner
                     }
                 }
                 else if (type.equals(INTEGER)) {
-                    writeVectorValues(output, vector, index -> type.writeLong(output, ((IntVector) vector).get(index)),
-                            offset, length);
+                    if (vector instanceof UInt4Vector uint4Vector) {
+                        writeVectorValues(output, vector,
+                                index -> type.writeLong(output, uint4Vector.get(index)), offset, length);
+                    }
+                    else {
+                        writeVectorValues(output, vector, index -> type.writeLong(output, ((IntVector) vector).get(index)),
+                                offset, length);
+                    }
                 }
                 else if (type.equals(DATE)) {
                     writeVectorValues(output, vector,

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
@@ -326,7 +326,7 @@ public class LanceArrowToPageScanner
                 else if (type.equals(INTEGER)) {
                     if (vector instanceof UInt4Vector uint4Vector) {
                         writeVectorValues(output, vector,
-                                index -> type.writeLong(output, uint4Vector.get(index)), offset, length);
+                                index -> type.writeLong(output, Integer.toUnsignedLong(uint4Vector.get(index))), offset, length);
                     }
                     else {
                         writeVectorValues(output, vector, index -> type.writeLong(output, ((IntVector) vector).get(index)),


### PR DESCRIPTION
the INTEGER branch only handled IntVector (signed int32), but Lance can store unsigned int32 fields (e.g., checksum inside structs) as UInt4Vector. Added UInt4Vector handling, mirroring the existing UInt8Vector pattern for BIGINT.