### PR TITLE
chore: update lance dependency to v6.0.0-rc.1

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>6.0.0-rc.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.7.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.7.2</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -185,12 +184,11 @@ public class LancePageSink
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Credentials have expiration - use namespace client for auto-refresh
                     fragmentWriter = fragmentWriter
                             .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
                 else {
                     // Static credentials - use storage options directly without provider


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `6.0.0-rc.1`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.2`, matching the Lance 6.0.0 RC source POM.
- Update Lance page sink credential refresh wiring to use the RC `WriteFragmentBuilder.namespaceClient(...).tableId(...)` API.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet expose `org.lance:lance-core:6.0.0-rc.1` during verification, so the artifact was installed locally from the upstream `lance-format/lance` `refs/tags/v6.0.0-rc.1` source tag before running the checks.

Triggering tag: `refs/tags/v6.0.0-rc.1`
