### PR TITLE
chore: update lance dependency to v6.0.0-rc.2

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>6.0.0-rc.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.7.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.7.2</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -186,11 +185,10 @@ public class LancePageSink
             if (storageOptions != null && !storageOptions.isEmpty()) {
                 if (storageOptions.containsKey("expires_at_millis")) {
                     // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
                     fragmentWriter = fragmentWriter
                             .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
                 else {
                     // Static credentials - use storage options directly without provider


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `6.0.0-rc.2`.
- Update `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.2`, matching the Lance `v6.0.0-rc.2` source POM.
- Adapt fragment writes to the `WriteFragmentBuilder.namespaceClient(...).tableId(...)` API used by Lance `6.0.0-rc.2` for namespace credential refresh.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet have `org.lance:lance-core:6.0.0-rc.2` available during verification, so I installed the artifact locally from the upstream `lance-format/lance` `refs/tags/v6.0.0-rc.2` source before running the checks.

Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v6.0.0-rc.2
