### PR TITLE
chore: update lance dependency to v7.0.0-beta.3

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>4.0.0</version>
+            <version>7.0.0-beta.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.5.2</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.5.2</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -27,7 +27,6 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.WriteFragmentBuilder;
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -184,17 +183,12 @@ public class LancePageSink
             }
 
             if (storageOptions != null && !storageOptions.isEmpty()) {
+                fragmentWriter = fragmentWriter.storageOptions(storageOptions);
                 if (storageOptions.containsKey("expires_at_millis")) {
-                    // Credentials have expiration - use provider for auto-refresh
-                    LanceNamespaceStorageOptionsProvider storageOptionsProvider =
-                            new LanceNamespaceStorageOptionsProvider(namespace, tableId);
+                    // Credentials have expiration - use namespace client for auto-refresh
                     fragmentWriter = fragmentWriter
-                            .storageOptions(storageOptions)
-                            .storageOptionsProvider(storageOptionsProvider);
-                }
-                else {
-                    // Static credentials - use storage options directly without provider
-                    fragmentWriter = fragmentWriter.storageOptions(storageOptions);
+                            .namespaceClient(namespace)
+                            .tableId(tableId);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` to `7.0.0-beta.3`.
- Updates Lance Namespace dependencies to `0.7.5`, matching the `v7.0.0-beta.3` Lance source POM.
- Updates page sink credential refresh wiring to use the new `WriteFragmentBuilder.namespaceClient(...).tableId(...)` API.

## Verification
- `make lint`
- `make compile`

Triggering tag: https://github.com/lancedb/lance/tree/refs/tags/v7.0.0-beta.3
