### PR TITLE
fix: coalesce splits for LIMIT queries

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
@@ -66,18 +66,11 @@ public class LanceSplitManager
         List<Fragment> allFragments = runtime.getFragments(
                 userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
 
-        // When a LIMIT is set without a filter, coalesce just enough fragments into a
-        // single split instead of creating one split per fragment. Without this, each
-        // fragment gets its own split and each applies the full LIMIT, reading
-        // (numFragments * LIMIT) rows instead of LIMIT. For tables with large rows
-        // (e.g. 165MB each), this OOMs workers.
-        //
-        // We accumulate per-fragment logical row counts until the LIMIT is reached.
-        // Fragment.metadata().getNumRows() is deletion-aware (physicalRows -
-        // numDeletions), so fragments emptied by deletion vectors contribute 0 and we
-        // keep walking until enough live rows are covered, while a single large
-        // fragment can satisfy a small LIMIT on its own. The counts come from the
-        // manifest already loaded when the dataset was opened, so this adds no IO.
+        // With a LIMIT and no filter, coalesce just enough fragments into one split
+        // instead of one-split-per-fragment (which reads numFragments * LIMIT rows
+        // and OOMs workers on large rows). getNumRows() is deletion-aware, so
+        // fully-deleted fragments contribute 0 and we walk on; it comes from the
+        // already-loaded manifest, so no extra IO.
         if (lanceTableHandle.getLimit().isPresent() && !lanceTableHandle.hasFilter()) {
             long limit = lanceTableHandle.getLimit().getAsLong();
             List<Integer> ids = allFragments.stream().map(Fragment::getId).toList();
@@ -95,19 +88,10 @@ public class LanceSplitManager
     }
 
     /**
-     * Selects the prefix of fragments whose cumulative logical (post-deletion) row
-     * count covers {@code limit}, returning their fragment IDs.
-     *
-     * <p>{@code rowCounts} must already account for deletion vectors (e.g.
-     * {@code Fragment.metadata().getNumRows()}). Fragments emptied by deletions
-     * contribute 0 and are effectively skipped, so the scan still sees enough live
-     * rows; conversely a single large fragment satisfies a small limit on its own.
-     * The result always contains at least one fragment (when any exist) so the scan
-     * is never handed an empty split.
-     *
-     * @param fragmentIds fragment IDs, in scan order
-     * @param rowCounts   parallel list of per-fragment logical row counts
-     * @param limit       the pushed-down LIMIT
+     * Returns the leading fragment IDs whose cumulative post-deletion row count
+     * covers {@code limit}. {@code rowCounts} must be deletion-aware (e.g.
+     * {@code Fragment.metadata().getNumRows()}) so emptied fragments contribute 0.
+     * Always returns at least one fragment when any exist.
      */
     static List<Integer> coalesceFragmentsForLimit(List<Integer> fragmentIds, List<Long> rowCounts, long limit)
     {

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
@@ -65,7 +65,22 @@ public class LanceSplitManager
         List<Fragment> allFragments = runtime.getFragments(
                 userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
 
-        // Create one split per fragment
+        // When a LIMIT is set without a filter, coalesce a small number of fragments
+        // into a single split instead of creating one split per fragment.
+        // Without this, each fragment gets its own split and each applies the full LIMIT,
+        // resulting in (numFragments * LIMIT) rows read instead of just LIMIT rows.
+        // For tables with large rows (e.g. 165MB each), this causes OOM on workers.
+        // We cap the number of fragments to avoid excessive metadata loading in the
+        // native scanner while ensuring enough fragments to satisfy the LIMIT.
+        if (lanceTableHandle.getLimit().isPresent() && !lanceTableHandle.hasFilter()) {
+            long limit = lanceTableHandle.getLimit().getAsLong();
+            int maxFragments = (int) Math.min(Math.max(limit, 1), allFragments.size());
+            List<Integer> fragmentIds = allFragments.subList(0, maxFragments).stream()
+                    .map(Fragment::getId).toList();
+            return new FixedSplitSource(List.of(new LanceSplit(fragmentIds)));
+        }
+
+        // Create one split per fragment for full scans and filtered queries
         // Lance will automatically use indexes during scanning when substrait filter is applied
         return new FixedSplitSource(allFragments.stream()
                 .map(frag -> new LanceSplit(Collections.singletonList(frag.getId())))

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
@@ -26,6 +26,7 @@ import org.lance.Fragment;
 import org.lance.namespace.model.DescribeTableRequest;
 import org.lance.namespace.model.DescribeTableResponse;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,18 +66,24 @@ public class LanceSplitManager
         List<Fragment> allFragments = runtime.getFragments(
                 userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
 
-        // When a LIMIT is set without a filter, coalesce a small number of fragments
-        // into a single split instead of creating one split per fragment.
-        // Without this, each fragment gets its own split and each applies the full LIMIT,
-        // resulting in (numFragments * LIMIT) rows read instead of just LIMIT rows.
-        // For tables with large rows (e.g. 165MB each), this causes OOM on workers.
-        // We cap the number of fragments to avoid excessive metadata loading in the
-        // native scanner while ensuring enough fragments to satisfy the LIMIT.
+        // When a LIMIT is set without a filter, coalesce just enough fragments into a
+        // single split instead of creating one split per fragment. Without this, each
+        // fragment gets its own split and each applies the full LIMIT, reading
+        // (numFragments * LIMIT) rows instead of LIMIT. For tables with large rows
+        // (e.g. 165MB each), this OOMs workers.
+        //
+        // We accumulate per-fragment logical row counts until the LIMIT is reached.
+        // Fragment.metadata().getNumRows() is deletion-aware (physicalRows -
+        // numDeletions), so fragments emptied by deletion vectors contribute 0 and we
+        // keep walking until enough live rows are covered, while a single large
+        // fragment can satisfy a small LIMIT on its own. The counts come from the
+        // manifest already loaded when the dataset was opened, so this adds no IO.
         if (lanceTableHandle.getLimit().isPresent() && !lanceTableHandle.hasFilter()) {
             long limit = lanceTableHandle.getLimit().getAsLong();
-            int maxFragments = (int) Math.min(Math.max(limit, 1), allFragments.size());
-            List<Integer> fragmentIds = allFragments.subList(0, maxFragments).stream()
-                    .map(Fragment::getId).toList();
+            List<Integer> ids = allFragments.stream().map(Fragment::getId).toList();
+            List<Long> rowCounts = allFragments.stream()
+                    .map(fragment -> fragment.metadata().getNumRows()).toList();
+            List<Integer> fragmentIds = coalesceFragmentsForLimit(ids, rowCounts, limit);
             return new FixedSplitSource(List.of(new LanceSplit(fragmentIds)));
         }
 
@@ -85,6 +92,35 @@ public class LanceSplitManager
         return new FixedSplitSource(allFragments.stream()
                 .map(frag -> new LanceSplit(Collections.singletonList(frag.getId())))
                 .toList());
+    }
+
+    /**
+     * Selects the prefix of fragments whose cumulative logical (post-deletion) row
+     * count covers {@code limit}, returning their fragment IDs.
+     *
+     * <p>{@code rowCounts} must already account for deletion vectors (e.g.
+     * {@code Fragment.metadata().getNumRows()}). Fragments emptied by deletions
+     * contribute 0 and are effectively skipped, so the scan still sees enough live
+     * rows; conversely a single large fragment satisfies a small limit on its own.
+     * The result always contains at least one fragment (when any exist) so the scan
+     * is never handed an empty split.
+     *
+     * @param fragmentIds fragment IDs, in scan order
+     * @param rowCounts   parallel list of per-fragment logical row counts
+     * @param limit       the pushed-down LIMIT
+     */
+    static List<Integer> coalesceFragmentsForLimit(List<Integer> fragmentIds, List<Long> rowCounts, long limit)
+    {
+        List<Integer> selected = new ArrayList<>();
+        long accumulated = 0;
+        for (int i = 0; i < fragmentIds.size() && accumulated < limit; i++) {
+            selected.add(fragmentIds.get(i));
+            accumulated += rowCounts.get(i);
+        }
+        if (selected.isEmpty() && !fragmentIds.isEmpty()) {
+            selected.add(fragmentIds.get(0));
+        }
+        return selected;
     }
 
     /**

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
@@ -90,9 +90,46 @@ public class TestLanceSplitManager
                 null, TestingConnectorSession.SESSION, withLimit, null, null);
         List<LanceSplit> splits = getAllSplits(splitSource);
 
-        // Should produce a single split with 1 fragment (min of limit=1, totalFragments=2))
+        // Fragment 0 holds 2 rows, which alone covers LIMIT 1, so only 1 fragment
+        // is coalesced into the single split.
         assertThat(splits).hasSize(1);
         assertThat(splits.get(0).getFragments()).hasSize(1);
+    }
+
+    @Test
+    public void testLimitStopsAtFirstFragmentWhenRowsSatisfyLimit()
+            throws ExecutionException, InterruptedException
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        // LIMIT 2 == fragment 0's full row count. The positional logic would have
+        // grabbed 2 fragments (min(limit, numFragments)); the row-count logic stops
+        // after fragment 0 since it already satisfies the limit.
+        LanceTableHandle withLimit = tableHandle.withLimit(2);
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, withLimit, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getFragments()).hasSize(1);
+    }
+
+    @Test
+    public void testLimitSpansFragmentsWhenFirstInsufficient()
+            throws ExecutionException, InterruptedException
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        // LIMIT 3 exceeds fragment 0's 2 rows, so fragment 1 is pulled in as well.
+        LanceTableHandle withLimit = tableHandle.withLimit(3);
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, withLimit, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getFragments()).hasSize(2);
     }
 
     @Test
@@ -102,7 +139,7 @@ public class TestLanceSplitManager
         LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
                 TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
 
-        // Apply LIMIT larger than the number of fragments
+        // Apply a LIMIT larger than the table's total row count (4 rows)
         LanceTableHandle withLimit = tableHandle.withLimit(100);
         ConnectorSplitSource splitSource = splitManager.getSplits(
                 null, TestingConnectorSession.SESSION, withLimit, null, null);
@@ -133,6 +170,49 @@ public class TestLanceSplitManager
         for (LanceSplit split : splits) {
             assertThat(split.getFragments()).hasSize(1);
         }
+    }
+
+    @Test
+    public void testCoalesceSkipsDeletionEmptiedFragments()
+    {
+        // Fragments 10 and 11 are fully deleted (0 logical rows); the only live rows
+        // are in fragment 12. Positional selection of LIMIT fragments would have
+        // returned [10, 11] and yielded 0 rows — the bug this fixes. Row-count
+        // accumulation keeps walking past the empty fragments to reach fragment 12.
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(10, 11, 12), List.of(0L, 0L, 2L), 2))
+                .containsExactly(10, 11, 12);
+
+        // A single large fragment satisfies a small limit on its own.
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(0, 1), List.of(5L, 5L), 3))
+                .containsExactly(0);
+
+        // Exact-fit: fragment 0's count equals the limit, so fragment 1 is not needed.
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(0, 1), List.of(2L, 2L), 2))
+                .containsExactly(0);
+
+        // Limit spills into the next fragment when the first is insufficient.
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(0, 1), List.of(2L, 2L), 3))
+                .containsExactly(0, 1);
+
+        // Every fragment fully deleted: return them all (table is logically empty,
+        // scan correctly yields fewer rows than the limit).
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(0, 1), List.of(0L, 0L), 5))
+                .containsExactly(0, 1);
+
+        // Never emit an empty split: LIMIT 0 still selects the first fragment.
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(7, 8), List.of(2L, 2L), 0))
+                .containsExactly(7);
+
+        // No fragments at all -> empty selection (no split to emit).
+        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
+                List.of(), List.of(), 5))
+                .isEmpty();
     }
 
     private static List<LanceSplit> getAllSplits(ConnectorSplitSource splitSource)

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lance;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import io.airlift.json.JsonCodec;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+@TestInstance(PER_METHOD)
+public class TestLanceSplitManager
+{
+    private static final SchemaTableName TEST_TABLE_1 = new SchemaTableName("default", "test_table1");
+
+    private LanceMetadata metadata;
+    private LanceSplitManager splitManager;
+
+    @BeforeEach
+    public void setUp()
+            throws Exception
+    {
+        URL lanceURL = Resources.getResource(TestLanceSplitManager.class, "/example_db");
+        assertThat(lanceURL)
+                .describedAs("example db is null")
+                .isNotNull();
+        LanceConfig lanceConfig = new LanceConfig()
+                .setSingleLevelNs(true);
+        Map<String, String> catalogProperties = ImmutableMap.of("lance.root", lanceURL.toString());
+        LanceRuntime runtime = new LanceRuntime(lanceConfig, catalogProperties);
+        JsonCodec<LanceCommitTaskData> commitTaskDataCodec = JsonCodec.jsonCodec(LanceCommitTaskData.class);
+        JsonCodec<LanceMergeCommitData> mergeCommitDataCodec = JsonCodec.jsonCodec(LanceMergeCommitData.class);
+        this.metadata = new LanceMetadata(runtime, lanceConfig, commitTaskDataCodec, mergeCommitDataCodec);
+        this.splitManager = new LanceSplitManager(runtime);
+    }
+
+    @Test
+    public void testFullScanCreatesSplitPerFragment()
+            throws ExecutionException, InterruptedException
+    {
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, tableHandle, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        // test_table1 has 2 fragments, each should get its own split
+        assertThat(splits).hasSize(2);
+        for (LanceSplit split : splits) {
+            assertThat(split.getFragments()).hasSize(1);
+        }
+    }
+
+    @Test
+    public void testLimitWithoutFilterCoalescesSplits()
+            throws ExecutionException, InterruptedException
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        // Apply LIMIT 1 without a filter
+        LanceTableHandle withLimit = tableHandle.withLimit(1);
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, withLimit, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        // Should produce a single split with 1 fragment (min of limit=1, totalFragments=2))
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getFragments()).hasSize(1);
+    }
+
+    @Test
+    public void testLimitLargerThanFragmentsCoalescesAll()
+            throws ExecutionException, InterruptedException
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        // Apply LIMIT larger than the number of fragments
+        LanceTableHandle withLimit = tableHandle.withLimit(100);
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, withLimit, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        // Should produce a single split containing all fragments
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getFragments()).hasSize(2);
+    }
+
+    @Test
+    public void testLimitWithFilterDoesNotCoalesce()
+            throws ExecutionException, InterruptedException
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        // Apply both a LIMIT and a filter — coalescing should NOT apply
+        LanceTableHandle withLimitAndFilter = tableHandle
+                .withLimit(1)
+                .withSubstraitFilter(new byte[] {0x01}, List.of("x"));
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, withLimitAndFilter, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        // With a filter present, each fragment gets its own split
+        assertThat(splits).hasSize(2);
+        for (LanceSplit split : splits) {
+            assertThat(split.getFragments()).hasSize(1);
+        }
+    }
+
+    private static List<LanceSplit> getAllSplits(ConnectorSplitSource splitSource)
+            throws ExecutionException, InterruptedException
+    {
+        ConnectorSplitSource.ConnectorSplitBatch batch = splitSource.getNextBatch(100).get();
+        return batch.getSplits().stream()
+                .map(LanceSplit.class::cast)
+                .toList();
+    }
+}

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
@@ -90,8 +90,7 @@ public class TestLanceSplitManager
                 null, TestingConnectorSession.SESSION, withLimit, null, null);
         List<LanceSplit> splits = getAllSplits(splitSource);
 
-        // Fragment 0 holds 2 rows, which alone covers LIMIT 1, so only 1 fragment
-        // is coalesced into the single split.
+        // Fragment 0's 2 rows alone cover LIMIT 1, so only 1 fragment is selected.
         assertThat(splits).hasSize(1);
         assertThat(splits.get(0).getFragments()).hasSize(1);
     }
@@ -103,9 +102,8 @@ public class TestLanceSplitManager
         LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
                 TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
 
-        // LIMIT 2 == fragment 0's full row count. The positional logic would have
-        // grabbed 2 fragments (min(limit, numFragments)); the row-count logic stops
-        // after fragment 0 since it already satisfies the limit.
+        // LIMIT 2 == fragment 0's row count: stops at 1 fragment (old positional
+        // logic would have grabbed 2).
         LanceTableHandle withLimit = tableHandle.withLimit(2);
         ConnectorSplitSource splitSource = splitManager.getSplits(
                 null, TestingConnectorSession.SESSION, withLimit, null, null);
@@ -175,10 +173,8 @@ public class TestLanceSplitManager
     @Test
     public void testCoalesceSkipsDeletionEmptiedFragments()
     {
-        // Fragments 10 and 11 are fully deleted (0 logical rows); the only live rows
-        // are in fragment 12. Positional selection of LIMIT fragments would have
-        // returned [10, 11] and yielded 0 rows — the bug this fixes. Row-count
-        // accumulation keeps walking past the empty fragments to reach fragment 12.
+        // Fragments 10,11 fully deleted (0 rows): positional selection would stop
+        // at [10,11] and yield 0 rows; row-count accumulation walks on to live 12.
         assertThat(LanceSplitManager.coalesceFragmentsForLimit(
                 List.of(10, 11, 12), List.of(0L, 0L, 2L), 2))
                 .containsExactly(10, 11, 12);
@@ -198,8 +194,7 @@ public class TestLanceSplitManager
                 List.of(0, 1), List.of(2L, 2L), 3))
                 .containsExactly(0, 1);
 
-        // Every fragment fully deleted: return them all (table is logically empty,
-        // scan correctly yields fewer rows than the limit).
+        // Every fragment fully deleted: return all (table logically empty).
         assertThat(LanceSplitManager.coalesceFragmentsForLimit(
                 List.of(0, 1), List.of(0L, 0L), 5))
                 .containsExactly(0, 1);


### PR DESCRIPTION
This fix came up while running the query: `Select * from lance_table limit 10` to create a sample of a table. Trino is going through all the fragments but we are only looking for 10 rows. So now it only processes 10 fragments for cases where there is no `filtering`. 

In our infra, this really sped up our sample lookups.