### PR TITLE
fix: add RowType support to Substrait schema and test nested field filter behavior

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/SubstraitExpressionBuilder.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/SubstraitExpressionBuilder.java
@@ -39,6 +39,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DateType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.VarbinaryType;
@@ -532,7 +533,7 @@ public final class SubstraitExpressionBuilder
                 .setNullability(Nullability.NULLABILITY_REQUIRED);
 
         for (LanceColumnHandle column : columns) {
-            schemaBuilder.addNames(column.name());
+            addFieldNames(schemaBuilder, column.name(), column.trinoType());
             structBuilder.addTypes(trinoTypeToProtoType(column.trinoType()));
         }
         schemaBuilder.setStruct(structBuilder.build());
@@ -559,6 +560,23 @@ public final class SubstraitExpressionBuilder
 
         byte[] bytes = extendedExprBuilder.build().toByteArray();
         return ByteBuffer.wrap(bytes);
+    }
+
+    /**
+     * Recursively adds field names to the NamedStruct builder.
+     * Substrait NamedStruct uses a flattened list of names for all fields
+     * including nested struct children.
+     */
+    private static void addFieldNames(NamedStruct.Builder schemaBuilder, String name, io.trino.spi.type.Type type)
+    {
+        schemaBuilder.addNames(name);
+        if (type instanceof RowType rowType) {
+            List<RowType.Field> fields = rowType.getFields();
+            for (RowType.Field field : fields) {
+                String childName = field.getName().orElse("field");
+                addFieldNames(schemaBuilder, childName, field.getType());
+            }
+        }
     }
 
     /**
@@ -623,6 +641,14 @@ public final class SubstraitExpressionBuilder
         else if (trinoType instanceof VarbinaryType) {
             return builder.setBinary(io.substrait.proto.Type.Binary.newBuilder()
                     .setNullability(Nullability.NULLABILITY_NULLABLE)).build();
+        }
+        else if (trinoType instanceof RowType rowType) {
+            io.substrait.proto.Type.Struct.Builder structBuilder = io.substrait.proto.Type.Struct.newBuilder()
+                    .setNullability(Nullability.NULLABILITY_NULLABLE);
+            for (io.trino.spi.type.Type fieldType : rowType.getTypeParameters()) {
+                structBuilder.addTypes(trinoTypeToProtoType(fieldType));
+            }
+            return builder.setStruct(structBuilder.build()).build();
         }
 
         throw new UnsupportedOperationException("Unsupported type for Substrait proto: " + trinoType);

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceStructColumns.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceStructColumns.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.lance;
 
 import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,8 +30,7 @@ public class TestLanceStructColumns
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return LanceQueryRunner.builder()
-                .setUseTempDirectory(true)
+        return LanceQueryRunner.builderForWriteTests()
                 .build();
     }
 
@@ -151,6 +151,125 @@ public class TestLanceStructColumns
             assertQuery("SELECT column_name, data_type FROM information_schema.columns " +
                             "WHERE table_name = '" + tableName + "' ORDER BY ordinal_position",
                     "VALUES ('id', 'bigint'), ('metadata', 'row(name varchar, value bigint)')");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    // ===== Nested Field Filter Pushdown Tests =====
+
+    @Test
+    public void testFilterOnNestedFieldReturnsCorrectResults()
+    {
+        String tableName = "test_nested_filter_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName +
+                    " AS SELECT * FROM (VALUES " +
+                    "(CAST(1 AS BIGINT), CAST(ROW('alice', 10) AS ROW(name VARCHAR, value BIGINT))), " +
+                    "(CAST(2 AS BIGINT), CAST(ROW('bob', 20) AS ROW(name VARCHAR, value BIGINT))), " +
+                    "(CAST(3 AS BIGINT), CAST(ROW('charlie', 30) AS ROW(name VARCHAR, value BIGINT)))" +
+                    ") AS t(id, metadata)", 3);
+
+            // Filter on nested varchar field
+            assertQuery(
+                    "SELECT id FROM " + tableName + " WHERE metadata.name = 'bob'",
+                    "VALUES (CAST(2 AS BIGINT))");
+
+            // Filter on nested bigint field
+            assertQuery(
+                    "SELECT id FROM " + tableName + " WHERE metadata.value > 15",
+                    "VALUES (CAST(2 AS BIGINT)), (CAST(3 AS BIGINT))");
+
+            // Combined filter on nested and top-level fields
+            assertQuery(
+                    "SELECT metadata.name FROM " + tableName + " WHERE id > 1 AND metadata.value < 25",
+                    "VALUES ('bob')");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testFilterOnDeeplyNestedFieldReturnsCorrectResults()
+    {
+        String tableName = "test_deep_nested_filter_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName +
+                    " AS SELECT * FROM (VALUES " +
+                    "(CAST(1 AS BIGINT), CAST(ROW('outer1', ROW('inner1', 100)) AS ROW(label VARCHAR, nested ROW(label VARCHAR, num BIGINT)))), " +
+                    "(CAST(2 AS BIGINT), CAST(ROW('outer2', ROW('inner2', 200)) AS ROW(label VARCHAR, nested ROW(label VARCHAR, num BIGINT))))" +
+                    ") AS t(id, payload)", 2);
+
+            // Filter on deeply nested field
+            assertQuery(
+                    "SELECT id FROM " + tableName + " WHERE payload.nested.label = 'inner2'",
+                    "VALUES (CAST(2 AS BIGINT))");
+
+            assertQuery(
+                    "SELECT id FROM " + tableName + " WHERE payload.nested.num > 150",
+                    "VALUES (CAST(2 AS BIGINT))");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testNestedFieldFilterNotPushedDown()
+    {
+        String tableName = "test_nested_no_pushdown_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName +
+                    " AS SELECT * FROM (VALUES " +
+                    "(CAST(1 AS BIGINT), CAST(ROW('alice', 10) AS ROW(name VARCHAR, value BIGINT)))" +
+                    ") AS t(id, metadata)", 1);
+
+            // Verify nested field filter is NOT pushed down (no constraint in plan)
+            MaterializedResult explainResult = computeActual(
+                    "EXPLAIN SELECT id FROM " + tableName + " WHERE metadata.name = 'alice'");
+            String explainPlan = (String) explainResult.getMaterializedRows().get(0).getField(0);
+            // The nested field filter should NOT appear as a connector constraint
+            // It should be a FilterNode above the TableScan
+            assertThat(explainPlan).contains("Filter");
+
+            // But a top-level filter SHOULD be pushed down
+            explainResult = computeActual(
+                    "EXPLAIN SELECT id FROM " + tableName + " WHERE id = 1");
+            explainPlan = (String) explainResult.getMaterializedRows().get(0).getField(0);
+            assertThat(explainPlan).containsPattern("constraint.{0,10}id");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testMixedTopLevelAndNestedFieldFilter()
+    {
+        String tableName = "test_mixed_filter_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName +
+                    " AS SELECT * FROM (VALUES " +
+                    "(CAST(1 AS BIGINT), CAST(ROW('alice', 10) AS ROW(name VARCHAR, value BIGINT))), " +
+                    "(CAST(2 AS BIGINT), CAST(ROW('bob', 20) AS ROW(name VARCHAR, value BIGINT))), " +
+                    "(CAST(3 AS BIGINT), CAST(ROW('charlie', 30) AS ROW(name VARCHAR, value BIGINT)))" +
+                    ") AS t(id, metadata)", 3);
+
+            // Top-level filter should be pushed down, nested field filter should remain
+            assertQuery(
+                    "SELECT metadata.name FROM " + tableName + " WHERE id >= 2 AND metadata.value <= 20",
+                    "VALUES ('bob')");
+
+            // EXPLAIN should show top-level filter pushed down and nested filter remaining
+            MaterializedResult explainResult = computeActual(
+                    "EXPLAIN SELECT metadata.name FROM " + tableName + " WHERE id >= 2 AND metadata.value <= 20");
+            String explainPlan = (String) explainResult.getMaterializedRows().get(0).getField(0);
+            // id filter should be in constraint (pushed down)
+            assertThat(explainPlan).containsPattern("constraint.{0,10}id");
+            // nested filter should be in a FilterNode (not pushed down)
+            assertThat(explainPlan).contains("Filter");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestSubstraitExpressionBuilder.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestSubstraitExpressionBuilder.java
@@ -25,12 +25,14 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.VarbinaryType;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -401,5 +403,72 @@ public class TestSubstraitExpressionBuilder
 
         assertThat(result).isPresent();
         assertThat(result.get().remaining()).isGreaterThan(0);
+    }
+
+    // ===== RowType (nested field) tests =====
+
+    @Test
+    public void testRowTypeIsNotSupported()
+    {
+        // RowType (struct) columns should not be supported for filter pushdown
+        RowType rowType = RowType.from(List.of(
+                new RowType.Field(Optional.of("name"), VARCHAR),
+                new RowType.Field(Optional.of("value"), BIGINT)));
+        assertThat(SubstraitExpressionBuilder.isSupportedType(rowType)).isFalse();
+    }
+
+    @Test
+    public void testRowTypeDomainSkippedInTupleDomain()
+    {
+        // A TupleDomain containing only a RowType column should produce no filter
+        RowType rowType = RowType.from(List.of(
+                new RowType.Field(Optional.of("name"), VARCHAR)));
+        LanceColumnHandle structColumn = new LanceColumnHandle("metadata", rowType, true, 4);
+
+        // RowType columns cannot appear in TupleDomain equality directly,
+        // but if they did, they should be filtered out
+        List<LanceColumnHandle> columns = new ArrayList<>(ALL_COLUMNS);
+        columns.add(structColumn);
+        Map<String, Integer> ordinals = Map.of(
+                "id", 0, "big_id", 1, "name", 2, "active", 3, "metadata", 4);
+
+        // Only push down the supported INT column, not the struct
+        TupleDomain<LanceColumnHandle> domain = TupleDomain.withColumnDomains(
+                Map.of(INT_COLUMN, Domain.singleValue(INTEGER, 42L)));
+        Optional<ByteBuffer> result = SubstraitExpressionBuilder.tupleDomainToSubstrait(domain, columns, ordinals);
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    public void testFieldDereferenceNotExtracted()
+    {
+        // FieldDereference expressions (nested field access like struct.field) should NOT be extracted
+        // They should remain as remaining expressions for Trino to evaluate
+        io.trino.spi.expression.FieldDereference deref = new io.trino.spi.expression.FieldDereference(
+                VARCHAR,
+                new Variable("metadata", RowType.from(List.of(
+                        new RowType.Field(Optional.of("name"), VARCHAR),
+                        new RowType.Field(Optional.of("value"), BIGINT)))),
+                0); // field index 0 = "name"
+
+        // Build a comparison: metadata.name = 'alice'
+        ConnectorExpression comparison = new Call(
+                BOOLEAN,
+                io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME,
+                List.of(deref, new Constant(Slices.utf8Slice("alice"), VARCHAR)));
+
+        RowType rowType = RowType.from(List.of(
+                new RowType.Field(Optional.of("name"), VARCHAR),
+                new RowType.Field(Optional.of("value"), BIGINT)));
+        LanceColumnHandle structColumn = new LanceColumnHandle("metadata", rowType, true, 4);
+        Map<String, ColumnHandle> assignments = Map.of("metadata", structColumn);
+        Map<String, Integer> ordinals = Map.of("metadata", 0);
+
+        SubstraitExpressionBuilder.ExpressionExtractionResult result =
+                SubstraitExpressionBuilder.extractPushableExpressions(comparison, assignments, ordinals);
+
+        // FieldDereference should NOT be extracted - it should remain as the remaining expression
+        assertThat(result.substraitExpressions()).isEmpty();
+        assertThat(result.remainingExpression()).isEqualTo(comparison);
     }
 }


### PR DESCRIPTION
## Summary

- Add `RowType` (struct) support to Substrait schema serialization so tables with struct columns don't crash when other filters are pushed down
- Add tests validating that nested field filters are correctly left as remaining expressions (not pushed down), since upstream `datafusion-substrait` does not support `StructField` with child references
- Fix `TestLanceStructColumns` query runner to use `builderForWriteTests()`

## Context

A customer reported an error when filtering on nested struct fields:
```
Not supported: Direct reference StructField with child is not supported
```

Investigation found 3 blocking points:
1. **Trino connector** - `SubstraitExpressionBuilder` doesn't handle `FieldDereference`
2. **Lance `substrait.rs`** - rejects `StructField` with child in `remap_expr_references`
3. **`datafusion-substrait` v53.1.0** - upstream limitation in field reference consumer

Queries with nested field filters **work correctly** today (Trino evaluates them post-scan), but the schema serialization would fail if a table had struct columns and any other filter was pushed down.