### PR TITLE
chore: update lance dependency to v7.0.0-beta.9

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-beta.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Updates `org.lance:lance-core` to `7.0.0-beta.9`.
- Aligns `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.5`, matching the tagged Lance core POM for the beta.9 release.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet expose `org.lance:lance-core:7.0.0-beta.9`, so verification used the tagged Lance source installed into the local Maven cache from refs/tags/v7.0.0-beta.9.

Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v7.0.0-beta.9
