### PR TITLE
chore: update lance dependency to v7.0.0-beta.11

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-beta.11</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `7.0.0-beta.11`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.5`, matching the `lance-core` POM from the triggering tag.

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central did not yet contain `org.lance:lance-core:7.0.0-beta.11` during verification, so the tagged Lance Java artifact was installed into the runner's local Maven repository from `refs/tags/v7.0.0-beta.11` before running the checks.

Triggering tag: `refs/tags/v7.0.0-beta.11`
