### PR TITLE
chore: update lance dependency to v7.0.0-beta.12

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-beta.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `7.0.0-beta.12`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.5`, matching the `lance-core` 7.0.0 beta source POM.
- Triggering tag: [refs/tags/v7.0.0-beta.12](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.12)

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central returned 404 for `org.lance:lance-core:7.0.0-beta.12` at the requested POM URL during verification, so the artifact was built and installed locally from `lance-format/lance` tag `refs/tags/v7.0.0-beta.12` before running the checks.
