### PR TITLE
chore: update lance dependency to v7.0.0-beta.13

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-beta.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `6.0.0` to `7.0.0-beta.13`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` with the `lance-core` `v7.0.0-beta.13` source POM by using `0.7.5`.
- Triggering tag: `refs/tags/v7.0.0-beta.13`

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet expose `org.lance:lance-core:7.0.0-beta.13` during this run, so verification used a local install of the exact tagged Lance Java artifact from `refs/tags/v7.0.0-beta.13`.
