### PR TITLE
chore: update lance dependency to v7.0.0-beta.16

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-beta.16</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `7.0.0-beta.16`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` with the `v7.0.0-beta.16` Lance Java POM compatibility versions.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.16 (`refs/tags/v7.0.0-beta.16`).

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:7.0.0-beta.16` during verification, so the tagged Lance Java artifact was installed into the runner-local Maven cache from `refs/tags/v7.0.0-beta.16` before rerunning checks.
