### PR TITLE
chore: update lance dependency to v7.0.0-beta.17

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-beta.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `7.0.0-beta.17`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.5`, matching the `lance-core` POM from the triggering tag.

## Verification
- `make lint`
- `make compile`

Note: `org.lance:lance-core:7.0.0-beta.17` was not available from Maven Central during verification, so the tagged Lance Java artifact was installed locally from https://github.com/lancedb/lance/tree/refs/tags/v7.0.0-beta.17 before running the checks.

Triggering tag: https://github.com/lancedb/lance/tree/refs/tags/v7.0.0-beta.17
