### PR TITLE
chore: update lance dependency to v7.0.0-rc.1

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0-rc.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `7.0.0-rc.1`.
- Update compatible Lance namespace dependencies to `0.7.7`, matching the `lance-core` POM from the `v7.0.0-rc.1` tag.

## Verification
- `make lint` passed.
- `make compile` passed.
- Maven Central did not yet resolve `org.lance:lance-core:7.0.0-rc.1` from this runner, so the tagged `lance-format/lance` Java artifact was installed into the local Maven cache from `refs/tags/v7.0.0-rc.1` before running verification.

Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v7.0.0-rc.1
