### PR TITLE
chore: update lance dependency to v7.1.0-beta.1

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.1.0-beta.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `7.1.0-beta.1`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.7`, matching the Lance `refs/tags/v7.1.0-beta.1` source POM.

## Verification
- `make lint` passed.
- `make compile` passed.

Triggering tag: `refs/tags/v7.1.0-beta.1`

Note: Maven Central did not yet resolve `org.lance:lance-core:7.1.0-beta.1` from the requested repo1 URL during this run, so verification used the tagged Lance Java artifact installed into the runner's local Maven cache from `refs/tags/v7.1.0-beta.1`.
