### PR TITLE
chore: update lance dependency to v7.1.0-beta.2

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.1.0-beta.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `7.1.0-beta.2`.
- Align Lance namespace dependencies with the tagged Lance Java POM by updating `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.7`.
- Triggering tag: [refs/tags/v7.1.0-beta.2](https://github.com/lance-format/lance/releases/tag/v7.1.0-beta.2)

## Verification
- Installed the tagged `lance-core` Java artifact locally from `refs/tags/v7.1.0-beta.2` because Maven Central did not yet resolve `org.lance:lance-core:7.1.0-beta.2`.
- `make lint`
- `make compile`
