### PR TITLE
chore: update lance dependency to v7.1.0-beta.3

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.1.0-beta.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` to `7.1.0-beta.3`.
- Updates compatible Lance namespace dependencies to `0.7.7` based on the Lance `refs/tags/v7.1.0-beta.3` source POM.
- Triggering tag: refs/tags/v7.1.0-beta.3

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central did not yet expose `org.lance:lance-core:7.1.0-beta.3` during verification, so I installed the tagged Lance Java artifact locally from `lance-format/lance@refs/tags/v7.1.0-beta.3` to complete lint and compile checks.
