### PR TITLE
chore: update lance dependency to v7.2.0-beta.1

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.2.0-beta.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` to `7.2.0-beta.1`.
- Updates compatible Lance namespace dependencies to `0.7.7`, matching the upstream Lance Java POM for `refs/tags/v7.2.0-beta.1`.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.2.0-beta.1 (`refs/tags/v7.2.0-beta.1`).

## Verification
- `make lint` failed because Maven Central could not resolve `org.lance:lance-core:jar:7.2.0-beta.1`.
- `make compile` failed for the same unresolved `org.lance:lance-core:jar:7.2.0-beta.1` dependency.
- Confirmed the upstream Lance release/tag exists and the release workflow completed successfully, but the artifact is not yet available from Maven Central at verification time.
