### PR TITLE
chore: update lance dependency to v7.2.0-beta.2

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>7.2.0-beta.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `7.2.0-beta.2`.
- Update compatible Lance namespace dependencies to `0.7.7` based on the `lance-core` POM from `refs/tags/v7.2.0-beta.2`.

## Verification
- Installed `org.lance:lance-core:7.2.0-beta.2` locally from the Lance source tag because the artifact was not yet resolvable from Maven Central during verification.
- `make lint`
- `make compile`

Triggering tag: refs/tags/v7.2.0-beta.2
