### PR TITLE
chore: update lance dependency to v8.0.0-beta.4

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>8.0.0-beta.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` from `6.0.0` to `8.0.0-beta.4`.
- Updates `org.lance:lance-namespace-core` and `org.lance:lance-namespace-apache-client` to `0.7.7`, matching the tagged `lance-core` POM compatibility.

## Verification
- `make lint`
- `make compile`

Note: Maven Central returned 404 for `org.lance:lance-core:8.0.0-beta.4` during verification, so the artifact was installed locally from the upstream tag before rerunning the checks.

Triggering tag: [refs/tags/v8.0.0-beta.4](https://github.com/lance-format/lance/tree/refs/tags/v8.0.0-beta.4)
