### PR TITLE
chore: update lance dependency to v8.0.0-beta.5

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>8.0.0-beta.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `8.0.0-beta.5`.
- Align `org.lance:lance-namespace-core` and `org.lance:lance-namespace-apache-client` to `0.7.7`, matching the Lance `v8.0.0-beta.5` source POM.
- Triggering tag: refs/tags/v8.0.0-beta.5

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central did not yet resolve `org.lance:lance-core:8.0.0-beta.5` on this runner, so the tagged Lance Java artifact was installed into the local Maven cache from `lancedb/lance` at `refs/tags/v8.0.0-beta.5` before rerunning verification.
