### PR TITLE
chore: update lance dependency to v8.0.0-beta.6

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>8.0.0-beta.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` to `8.0.0-beta.6`.
- Update `org.lance:lance-namespace-core` and `org.lance:lance-namespace-apache-client` to `0.7.7`, matching the tagged Lance Java POM compatibility for `refs/tags/v8.0.0-beta.6`.

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central returned 404 for `org.lance:lance-core:8.0.0-beta.6` from this runner during the initial check, so I verified by installing the tagged Lance Java artifact from `refs/tags/v8.0.0-beta.6` into the local Maven cache before rerunning the checks.
