### PR TITLE
fix: optimize count over non-null constants

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceCountPageSource.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceCountPageSource.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static io.trino.spi.type.BigintType.BIGINT;
 
 /**
- * Page source for COUNT(*) queries without filter.
+ * Page source for row-count aggregate queries without filter.
  * Returns count from ManifestSummary (no data scan needed).
  */
 public class LanceCountPageSource
@@ -90,7 +90,7 @@ public class LanceCountPageSource
     private long computeCount()
     {
         ManifestSummary summary = runtime.getManifestSummary(userIdentity, tablePath, datasetVersion, storageOptions);
-        log.debug("COUNT(*) returning manifest count %d", summary.getTotalRows());
+        log.debug("Row-count aggregate returning manifest count %d", summary.getTotalRows());
         return summary.getTotalRows();
     }
 

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -47,6 +47,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.predicate.Domain;
@@ -576,7 +577,7 @@ public class LanceMetadata
                     summary.getTotalFragments());
 
             // Note: TableStatistics is used for query planning/cost estimation only.
-            // For COUNT(*) optimization, we would need to implement applyAggregation().
+            // The row-count fast path is handled by applyAggregation().
             return TableStatistics.builder()
                     .setRowCount(Estimate.of(summary.getTotalRows()))
                     .build();
@@ -616,36 +617,36 @@ public class LanceMetadata
             return Optional.empty();
         }
 
-        // Don't push COUNT(*) if there's a filter - let Trino aggregate distributed counts
+        // Don't push row-count aggregates if there's a table filter - let Trino aggregate distributed counts
         // We can only return a single row from aggregate pushdown, but with filter we need
         // to count each fragment separately which would return multiple rows
         if (lanceTableHandle.hasFilter()) {
-            log.debug("applyAggregation: not pushing COUNT(*) with filter");
+            log.debug("applyAggregation: not pushing row-count aggregate with filter");
             return Optional.empty();
         }
 
-        // Only support simple COUNT(*) without grouping
+        // Only push an ungrouped aggregate (a single, empty grouping set)
         if (groupingSets.size() != 1 || !groupingSets.get(0).isEmpty()) {
             return Optional.empty();
         }
 
-        // Only support single COUNT(*) aggregate
+        // Only support single row-count aggregate
         if (aggregates.size() != 1) {
             return Optional.empty();
         }
 
         AggregateFunction aggregate = aggregates.get(0);
-        if (!isCountStar(aggregate)) {
+        if (!isRowCountAggregate(aggregate)) {
             log.debug("applyAggregation: unsupported aggregate function: %s", aggregate.getFunctionName());
             return Optional.empty();
         }
 
-        log.debug("applyAggregation: pushing COUNT(*) for table %s (no filter)",
+        log.debug("applyAggregation: pushing row-count aggregate for table %s (no filter)",
                 lanceTableHandle.getTableName());
 
         LanceTableHandle newHandle = lanceTableHandle.withCountStar();
 
-        // Create synthetic column handle for COUNT(*) result
+        // Create synthetic column handle for the row-count result
         LanceColumnHandle countColumnHandle = new LanceColumnHandle("_count", aggregate.getOutputType(), false, -1);
         Variable variable = new Variable("_count", aggregate.getOutputType());
 
@@ -657,11 +658,29 @@ public class LanceMetadata
                 false));
     }
 
-    private boolean isCountStar(AggregateFunction aggregate)
+    private boolean isRowCountAggregate(AggregateFunction aggregate)
     {
-        return "count".equalsIgnoreCase(aggregate.getFunctionName()) &&
-                aggregate.getArguments().isEmpty() &&
-                !aggregate.isDistinct();
+        if (!"count".equalsIgnoreCase(aggregate.getFunctionName())) {
+            return false;
+        }
+        // Only a plain row count maps to the manifest total. Bail out if the aggregation is DISTINCT,
+        // has a FILTER (WHERE ...) clause, or carries in-aggregate sort items (ORDER BY) - none of which
+        // a manifest row count can satisfy.
+        if (aggregate.isDistinct() || !aggregate.getSortItems().isEmpty() || aggregate.getFilter().isPresent()) {
+            return false;
+        }
+        // COUNT(*) takes no argument. COUNT(<non-null constant>) is equivalent because the constant is
+        // never NULL for any row, so it also counts every row. In current Trino, SimplifyCountOverConstant
+        // rewrites COUNT(<non-null constant>) to COUNT(*) before pushdown, so SQL queries reach the
+        // empty-argument case above; this branch is reached only when an argument survives to the SPI
+        // (exercised directly by TestLanceMetadata).
+        List<ConnectorExpression> arguments = aggregate.getArguments();
+        if (arguments.isEmpty()) {
+            return true;
+        }
+        return arguments.size() == 1
+                && arguments.getFirst() instanceof Constant constant
+                && constant.getValue() != null;
     }
 
     @Override

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSourceProvider.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSourceProvider.java
@@ -65,7 +65,7 @@ public class LancePageSourceProvider
 
         String userIdentity = session.getUser();
 
-        // For COUNT(*) queries, use the count page source
+        // For row-count aggregate queries, use the count page source
         if (lanceTableHandle.isCountStar()) {
             return new LanceCountPageSource(lanceTableHandle, storageOptions, userIdentity, runtime);
         }

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
@@ -51,7 +51,7 @@ public class LanceSplitManager
     {
         LanceTableHandle lanceTableHandle = (LanceTableHandle) tableHandle;
 
-        // For COUNT(*) without filter, return a single empty split
+        // For row-count aggregates without filter, return a single empty split
         // The count will be retrieved from ManifestSummary without scanning data
         if (lanceTableHandle.isCountStar() && !lanceTableHandle.hasFilter()) {
             return new FixedSplitSource(List.of(new LanceSplit(Collections.emptyList())));

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceTableHandle.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceTableHandle.java
@@ -235,7 +235,7 @@ public class LanceTableHandle
     }
 
     /**
-     * Check if this is a COUNT(*) aggregate query.
+     * Check if this handle uses the manifest-backed row-count aggregate fast path.
      */
     @JsonProperty("countStar")
     public boolean isCountStar()
@@ -278,7 +278,7 @@ public class LanceTableHandle
     }
 
     /**
-     * Create a new handle for COUNT(*) aggregate.
+     * Create a new handle for the manifest-backed row-count aggregate fast path.
      */
     public LanceTableHandle withCountStar()
     {

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
@@ -216,6 +216,43 @@ public class TestLanceConnectorTest
                         "\\)");
     }
 
+    @Test
+    public void testCountAggregationPushdownBoundaries()
+    {
+        // End-to-end checks. Note Trino's SimplifyCountOverConstant rewrites count(<non-null constant>)
+        // to count(*) before pushdown, so these SQL cases reach the connector as count(*) and exercise the
+        // empty-argument path; the constant-argument branch of isRowCountAggregate is covered directly by
+        // TestLanceMetadata. These assertions guard the end-to-end behavior and against optimizer changes.
+        assertQuery("SELECT count(0) FROM region", "SELECT 5");
+        assertExplain("EXPLAIN SELECT count(0) FROM region", "countStar=true");
+
+        assertQuery("SELECT count(0) FROM region WHERE regionkey = 0", "SELECT 1");
+        assertThat((String) computeActual("EXPLAIN SELECT count(0) FROM region WHERE regionkey = 0").getOnlyValue())
+                .doesNotContain("countStar=true");
+
+        assertQuery("SELECT count(DISTINCT 0) FROM region", "SELECT 1");
+        assertThat((String) computeActual("EXPLAIN SELECT count(DISTINCT 0) FROM region").getOnlyValue())
+                .doesNotContain("countStar=true");
+
+        // The original COUNT(*) case must keep taking the fast path after generalizing the predicate.
+        assertQuery("SELECT count(*) FROM region", "SELECT 5");
+        assertExplain("EXPLAIN SELECT count(*) FROM region", "countStar=true");
+
+        // A non-numeric constant argument is also a row-count aggregate (again rewritten to count(*) upstream).
+        assertQuery("SELECT count(true) FROM region", "SELECT 5");
+        assertExplain("EXPLAIN SELECT count(true) FROM region", "countStar=true");
+
+        // GROUP BY must stay on the normal path (one count per group, not a single manifest count).
+        assertQuery("SELECT count(0) FROM region GROUP BY regionkey", "SELECT 1 FROM region");
+        assertThat((String) computeActual("EXPLAIN SELECT count(0) FROM region GROUP BY regionkey").getOnlyValue())
+                .doesNotContain("countStar=true");
+
+        // An aggregate-level FILTER must stay on the normal path.
+        assertQuery("SELECT count(0) FILTER (WHERE regionkey > 0) FROM region", "SELECT 4");
+        assertThat((String) computeActual("EXPLAIN SELECT count(0) FILTER (WHERE regionkey > 0) FROM region").getOnlyValue())
+                .doesNotContain("countStar=true");
+    }
+
     @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
@@ -18,9 +18,15 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import io.airlift.json.JsonCodec;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +38,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -151,6 +161,279 @@ public class TestLanceMetadata
                 .containsEntry("b", 1)
                 .containsEntry("c", 2)
                 .containsEntry("e", 3);
+    }
+
+    @Test
+    public void testCountNonNullConstantAggregationPushdown()
+    {
+        AggregateFunction countConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countConstant),
+                Map.of(),
+                List.of(List.of()));
+
+        assertThat(result).isPresent();
+        LanceTableHandle pushedHandle = (LanceTableHandle) result.orElseThrow().getHandle();
+        assertThat(pushedHandle.isCountStar()).isTrue();
+    }
+
+    @Test
+    public void testCountNullConstantAggregationNotPushedDown()
+    {
+        AggregateFunction countNullConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(null, INTEGER)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countNullConstant),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testFilteredCountConstantAggregationNotPushedDown()
+    {
+        AggregateFunction filteredCountConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(),
+                false,
+                Optional.of(Constant.FALSE));
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(filteredCountConstant),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testCountConstantAggregationWithTableFilterNotPushedDown()
+    {
+        AggregateFunction countConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE.withSubstraitFilter(new byte[] {1}, List.of("x")),
+                List.of(countConstant),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testDistinctCountConstantAggregationNotPushedDown()
+    {
+        AggregateFunction distinctCountConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(),
+                true,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(distinctCountConstant),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testCountColumnAggregationNotPushedDown()
+    {
+        AggregateFunction countColumn = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Variable("x", BIGINT)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countColumn),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testSortedCountConstantAggregationNotPushedDown()
+    {
+        AggregateFunction sortedCountConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(new SortItem("x", ASC_NULLS_LAST)),
+                false,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(sortedCountConstant),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testCountStarAggregationPushdown()
+    {
+        AggregateFunction countStar = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(),
+                List.of(),
+                false,
+                Optional.empty());
+
+        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countStar),
+                Map.of(),
+                List.of(List.of()));
+
+        assertThat(result).isPresent();
+        LanceTableHandle pushedHandle = (LanceTableHandle) result.orElseThrow().getHandle();
+        assertThat(pushedHandle.isCountStar()).isTrue();
+    }
+
+    @Test
+    public void testCountNonNumericConstantAggregationPushdown()
+    {
+        // The fast path is type-agnostic: any non-null constant argument counts every row, so a
+        // non-numeric constant such as count(true) is pushed down just like count(0).
+        AggregateFunction countBooleanConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(true, BOOLEAN)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countBooleanConstant),
+                Map.of(),
+                List.of(List.of()));
+
+        assertThat(result).isPresent();
+        LanceTableHandle pushedHandle = (LanceTableHandle) result.orElseThrow().getHandle();
+        assertThat(pushedHandle.isCountStar()).isTrue();
+    }
+
+    @Test
+    public void testMultipleAggregatesNotPushedDown()
+    {
+        AggregateFunction countConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countConstant, countConstant),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testGroupedCountConstantAggregationNotPushedDown()
+    {
+        AggregateFunction countConstant = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(new Constant(0L, INTEGER)),
+                List.of(),
+                false,
+                Optional.empty());
+        LanceColumnHandle groupColumn = new LanceColumnHandle("x", BIGINT, true, 0);
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(countConstant),
+                Map.of(),
+                List.of(List.of(groupColumn))))
+                .isEmpty();
+    }
+
+    @Test
+    public void testAlreadyPushedAggregationNotPushedDown()
+    {
+        AggregateFunction countStar = new AggregateFunction(
+                "count",
+                BIGINT,
+                List.of(),
+                List.of(),
+                false,
+                Optional.empty());
+
+        // A handle that already carries the row-count fast path must not be pushed a second time.
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE.withCountStar(),
+                List.of(countStar),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNonCountAggregationNotPushedDown()
+    {
+        AggregateFunction sum = new AggregateFunction(
+                "sum",
+                BIGINT,
+                List.of(new Variable("x", BIGINT)),
+                List.of(),
+                false,
+                Optional.empty());
+
+        assertThat(metadata.applyAggregation(
+                SESSION,
+                TEST_TABLE_1_HANDLE,
+                List.of(sum),
+                Map.of(),
+                List.of(List.of())))
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Treat `COUNT(non-null constant)` as a row-count aggregate so it can use the existing manifest-backed count fast path.
- Keep filtered, distinct, NULL, column, sorted, grouped, and multi-aggregate cases on the normal path.
- Add metadata and connector tests for the new pushdown and its boundary cases.

Fixes #142

## Verification
- `git diff --check`
- `JAVA_HOME=/Users/yangjie01/Tools/zulu25 ./mvnw test -pl plugin/trino-lance -Dtest=TestLanceMetadata#testCountNonNullConstantAggregationPushdown+testCountNullConstantAggregationNotPushedDown+testFilteredCountConstantAggregationNotPushedDown+testCountConstantAggregationWithTableFilterNotPushedDown+testDistinctCountConstantAggregationNotPushedDown+testCountColumnAggregationNotPushedDown+testSortedCountConstantAggregationNotPushedDown,TestLanceConnectorTest#testCountNonNullConstantPushdown -Dair.check.skip-enforcer=true -Dsurefire.forkCount=1`