### PR TITLE
fix: select prefix fragments for LIMIT queries

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceRuntime.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceRuntime.java
@@ -52,6 +52,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -392,6 +394,40 @@ public class LanceRuntime
     {
         Dataset dataset = getDataset(userIdentity, tablePath, version, storageOptions);
         return dataset.getFragments();
+    }
+
+    /**
+     * Returns leading fragment IDs whose deletion-aware row count covers an
+     * unfiltered limit, or all fragments when the limit cannot be reached.
+     * Zero-row fragments are preserved while walking the prefix, and LIMIT 0
+     * still selects the first fragment when any exist.
+     */
+    public List<Integer> selectPrefixFragmentIdsForLimit(String userIdentity, String tablePath, Long version,
+            Map<String, String> storageOptions, long limit)
+    {
+        return selectPrefixFragmentIdsForLimit(
+                getFragments(userIdentity, tablePath, version, storageOptions),
+                Fragment::getId,
+                fragment -> fragment.metadata().getNumRows(),
+                limit);
+    }
+
+    static <T> List<Integer> selectPrefixFragmentIdsForLimit(
+            Iterable<T> fragments,
+            ToIntFunction<T> fragmentId,
+            ToLongFunction<T> rowCount,
+            long limit)
+    {
+        List<Integer> selected = new ArrayList<>();
+        long accumulated = 0;
+        for (T fragment : fragments) {
+            selected.add(fragmentId.applyAsInt(fragment));
+            accumulated += rowCount.applyAsLong(fragment);
+            if (accumulated >= limit) {
+                break;
+            }
+        }
+        return selected;
     }
 
     public Fragment getFragment(String userIdentity, String tablePath, Long version,

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
@@ -26,7 +26,6 @@ import org.lance.Fragment;
 import org.lance.namespace.model.DescribeTableRequest;
 import org.lance.namespace.model.DescribeTableResponse;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -61,50 +60,25 @@ public class LanceSplitManager
         Map<String, String> storageOptions = getEffectiveStorageOptions(lanceTableHandle);
         String userIdentity = session.getUser();
 
+        // With a LIMIT and no filter, select just enough leading fragments into
+        // one split instead of scheduling one split per fragment.
+        if (lanceTableHandle.getLimit().isPresent() && !lanceTableHandle.hasFilter()) {
+            long limit = lanceTableHandle.getLimit().getAsLong();
+            List<Integer> fragmentIds = runtime.selectPrefixFragmentIdsForLimit(
+                    userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions, limit);
+            return new FixedSplitSource(List.of(new LanceSplit(fragmentIds)));
+        }
+
         // Get all fragments
         // Use the version captured in the table handle for snapshot isolation
         List<Fragment> allFragments = runtime.getFragments(
                 userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
-
-        // With a LIMIT and no filter, coalesce just enough fragments into one split
-        // instead of one-split-per-fragment (which reads numFragments * LIMIT rows
-        // and OOMs workers on large rows). getNumRows() is deletion-aware, so
-        // fully-deleted fragments contribute 0 and we walk on; it comes from the
-        // already-loaded manifest, so no extra IO.
-        if (lanceTableHandle.getLimit().isPresent() && !lanceTableHandle.hasFilter()) {
-            long limit = lanceTableHandle.getLimit().getAsLong();
-            List<Integer> ids = allFragments.stream().map(Fragment::getId).toList();
-            List<Long> rowCounts = allFragments.stream()
-                    .map(fragment -> fragment.metadata().getNumRows()).toList();
-            List<Integer> fragmentIds = coalesceFragmentsForLimit(ids, rowCounts, limit);
-            return new FixedSplitSource(List.of(new LanceSplit(fragmentIds)));
-        }
 
         // Create one split per fragment for full scans and filtered queries
         // Lance will automatically use indexes during scanning when substrait filter is applied
         return new FixedSplitSource(allFragments.stream()
                 .map(frag -> new LanceSplit(Collections.singletonList(frag.getId())))
                 .toList());
-    }
-
-    /**
-     * Returns the leading fragment IDs whose cumulative post-deletion row count
-     * covers {@code limit}. {@code rowCounts} must be deletion-aware (e.g.
-     * {@code Fragment.metadata().getNumRows()}) so emptied fragments contribute 0.
-     * Always returns at least one fragment when any exist.
-     */
-    static List<Integer> coalesceFragmentsForLimit(List<Integer> fragmentIds, List<Long> rowCounts, long limit)
-    {
-        List<Integer> selected = new ArrayList<>();
-        long accumulated = 0;
-        for (int i = 0; i < fragmentIds.size() && accumulated < limit; i++) {
-            selected.add(fragmentIds.get(i));
-            accumulated += rowCounts.get(i);
-        }
-        if (selected.isEmpty() && !fragmentIds.isEmpty()) {
-            selected.add(fragmentIds.get(0));
-        }
-        return selected;
     }
 
     /**

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
@@ -216,6 +216,22 @@ public class TestLanceConnectorTest
                         "\\)");
     }
 
+    @Test
+    public void testLimitQueriesArePushedIntoTableHandle()
+    {
+        assertThat(computeActual("SELECT name FROM region LIMIT 1").getRowCount())
+                .isLessThanOrEqualTo(1);
+        assertExplain("EXPLAIN SELECT name FROM region LIMIT 1", "limit.{0,10}OptionalLong\\[1\\]");
+
+        assertThat(computeActual("SELECT name FROM region LIMIT 10").getRowCount())
+                .isLessThanOrEqualTo(10);
+        assertExplain("EXPLAIN SELECT name FROM region LIMIT 10", "limit.{0,10}OptionalLong\\[10\\]");
+
+        assertThat(computeActual("SELECT name FROM region LIMIT 100").getRowCount())
+                .isLessThanOrEqualTo(100);
+        assertExplain("EXPLAIN SELECT name FROM region LIMIT 100", "limit.{0,10}OptionalLong\\[100\\]");
+    }
+
     @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
@@ -72,9 +72,8 @@ public class TestLanceSplitManager
 
         // test_table1 has 2 fragments, each should get its own split
         assertThat(splits).hasSize(2);
-        for (LanceSplit split : splits) {
-            assertThat(split.getFragments()).hasSize(1);
-        }
+        assertThat(splits.stream().map(LanceSplit::getFragments).toList())
+                .containsExactly(List.of(0), List.of(1));
     }
 
     @Test
@@ -92,7 +91,7 @@ public class TestLanceSplitManager
 
         // Fragment 0's 2 rows alone cover LIMIT 1, so only 1 fragment is selected.
         assertThat(splits).hasSize(1);
-        assertThat(splits.get(0).getFragments()).hasSize(1);
+        assertThat(splits.get(0).getFragments()).containsExactly(0);
     }
 
     @Test
@@ -110,7 +109,7 @@ public class TestLanceSplitManager
         List<LanceSplit> splits = getAllSplits(splitSource);
 
         assertThat(splits).hasSize(1);
-        assertThat(splits.get(0).getFragments()).hasSize(1);
+        assertThat(splits.get(0).getFragments()).containsExactly(0);
     }
 
     @Test
@@ -127,7 +126,7 @@ public class TestLanceSplitManager
         List<LanceSplit> splits = getAllSplits(splitSource);
 
         assertThat(splits).hasSize(1);
-        assertThat(splits.get(0).getFragments()).hasSize(2);
+        assertThat(splits.get(0).getFragments()).containsExactly(0, 1);
     }
 
     @Test
@@ -145,7 +144,7 @@ public class TestLanceSplitManager
 
         // Should produce a single split containing all fragments
         assertThat(splits).hasSize(1);
-        assertThat(splits.get(0).getFragments()).hasSize(2);
+        assertThat(splits.get(0).getFragments()).containsExactly(0, 1);
     }
 
     @Test
@@ -165,49 +164,71 @@ public class TestLanceSplitManager
 
         // With a filter present, each fragment gets its own split
         assertThat(splits).hasSize(2);
-        for (LanceSplit split : splits) {
-            assertThat(split.getFragments()).hasSize(1);
-        }
+        assertThat(splits.stream().map(LanceSplit::getFragments).toList())
+                .containsExactly(List.of(0), List.of(1));
     }
 
     @Test
-    public void testCoalesceSkipsDeletionEmptiedFragments()
+    public void testPrefixFragmentSelectionSkipsDeletionEmptiedFragments()
     {
         // Fragments 10,11 fully deleted (0 rows): positional selection would stop
         // at [10,11] and yield 0 rows; row-count accumulation walks on to live 12.
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(10, 11, 12), List.of(0L, 0L, 2L), 2))
+        assertThat(selectPrefixFragmentIdsForLimit(
+                List.of(new TestFragment(10, 0), new TestFragment(11, 0), new TestFragment(12, 2)), 2))
                 .containsExactly(10, 11, 12);
 
         // A single large fragment satisfies a small limit on its own.
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(0, 1), List.of(5L, 5L), 3))
+        assertThat(selectPrefixFragmentIdsForLimit(
+                List.of(new TestFragment(0, 5), new TestFragment(1, 5)), 3))
                 .containsExactly(0);
 
         // Exact-fit: fragment 0's count equals the limit, so fragment 1 is not needed.
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(0, 1), List.of(2L, 2L), 2))
+        assertThat(selectPrefixFragmentIdsForLimit(
+                List.of(new TestFragment(0, 2), new TestFragment(1, 2)), 2))
                 .containsExactly(0);
 
         // Limit spills into the next fragment when the first is insufficient.
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(0, 1), List.of(2L, 2L), 3))
+        assertThat(selectPrefixFragmentIdsForLimit(
+                List.of(new TestFragment(0, 2), new TestFragment(1, 2)), 3))
                 .containsExactly(0, 1);
 
         // Every fragment fully deleted: return all (table logically empty).
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(0, 1), List.of(0L, 0L), 5))
+        assertThat(selectPrefixFragmentIdsForLimit(
+                List.of(new TestFragment(0, 0), new TestFragment(1, 0)), 5))
                 .containsExactly(0, 1);
 
         // Never emit an empty split: LIMIT 0 still selects the first fragment.
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(7, 8), List.of(2L, 2L), 0))
+        assertThat(selectPrefixFragmentIdsForLimit(
+                List.of(new TestFragment(7, 2), new TestFragment(8, 2)), 0))
                 .containsExactly(7);
 
-        // No fragments at all -> empty selection (no split to emit).
-        assertThat(LanceSplitManager.coalesceFragmentsForLimit(
-                List.of(), List.of(), 5))
+        // No fragments at all -> empty selection. The caller decides how to wrap it.
+        assertThat(selectPrefixFragmentIdsForLimit(List.<TestFragment>of(), 5))
                 .isEmpty();
+    }
+
+    @Test
+    public void testPrefixFragmentSelectionSupportsArbitraryLimitValues()
+    {
+        List<TestFragment> fragments = List.of(
+                new TestFragment(1, 5),
+                new TestFragment(2, 20),
+                new TestFragment(3, 500),
+                new TestFragment(4, 1_000));
+
+        assertThat(selectPrefixFragmentIdsForLimit(fragments, 10))
+                .containsExactly(1, 2);
+
+        assertThat(selectPrefixFragmentIdsForLimit(fragments, 100))
+                .containsExactly(1, 2, 3);
+
+        assertThat(selectPrefixFragmentIdsForLimit(fragments, 1_000))
+                .containsExactly(1, 2, 3, 4);
+    }
+
+    private static List<Integer> selectPrefixFragmentIdsForLimit(List<TestFragment> fragments, long limit)
+    {
+        return LanceRuntime.selectPrefixFragmentIdsForLimit(fragments, TestFragment::id, TestFragment::rowCount, limit);
     }
 
     private static List<LanceSplit> getAllSplits(ConnectorSplitSource splitSource)
@@ -218,4 +239,6 @@ public class TestLanceSplitManager
                 .map(LanceSplit.class::cast)
                 .toList();
     }
+
+    private record TestFragment(int id, long rowCount) {}
 }


### PR DESCRIPTION
## Summary
- select prefix fragment IDs for unfiltered LIMIT queries through LanceRuntime
- avoid building full fragment id and row-count lists in the split manager
- cover arbitrary LIMIT N pushdown and prefix fragment order

## Scope
This is a narrow follow-up to #121. It does not avoid Lance's full `Dataset.getFragments()` enumeration, and it does not address filtered or aggregate LIMIT queries.

## Verification
- `git diff --check`
- `./mvnw -pl plugin/trino-lance -Dtest=TestLanceSplitManager,TestLanceConnectorTest test`