### PR TITLE
chore: update lance dependency to v8.0.0-beta.7

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>6.0.0</version>
+            <version>8.0.0-beta.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `8.0.0-beta.7`.
- Update compatible Lance namespace dependencies to `0.7.7`, matching the Lance `v8.0.0-beta.7` Java POM.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet list `org.lance:lance-core:8.0.0-beta.7` during verification, so the tagged Lance Java artifact was installed into the runner's local Maven cache from `refs/tags/v8.0.0-beta.7` before running the checks.

Triggering tag: `refs/tags/v8.0.0-beta.7`
