### PR TITLE
fix: avoid fragment enumeration for filtered LIMIT queries

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
@@ -156,13 +156,52 @@ public class LanceArrowToPageScanner
             }
         }
 
-        lanceScanner = scannerFactory.open(path, allocator, projectionColumns, storageOptions, substraitFilter, limit, userIdentity, datasetVersion);
-        this.arrowReader = lanceScanner.scanBatches();
+        LanceScanner openedScanner = null;
+        ArrowReader openedReader = null;
         try {
-            this.vectorSchemaRoot = arrowReader.getVectorSchemaRoot();
+            openedScanner = scannerFactory.open(path, allocator, projectionColumns, storageOptions, substraitFilter, limit, userIdentity, datasetVersion);
+            openedReader = openedScanner.scanBatches();
+            VectorSchemaRoot openedRoot = openedReader.getVectorSchemaRoot();
+            this.lanceScanner = openedScanner;
+            this.arrowReader = openedReader;
+            this.vectorSchemaRoot = openedRoot;
         }
         catch (IOException e) {
-            throw new RuntimeException("Unable to get vector schema root", e);
+            RuntimeException failure = new RuntimeException("Unable to get vector schema root", e);
+            closeSuppressing(openedReader, failure);
+            closeFactorySuppressing(scannerFactory, failure);
+            throw failure;
+        }
+        catch (RuntimeException e) {
+            closeSuppressing(openedReader, e);
+            closeFactorySuppressing(scannerFactory, e);
+            throw e;
+        }
+    }
+
+    private static void closeSuppressing(AutoCloseable closeable, RuntimeException failure)
+    {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        }
+        catch (Exception closeFailure) {
+            failure.addSuppressed(closeFailure);
+        }
+    }
+
+    private static void closeFactorySuppressing(ScannerFactory scannerFactory, RuntimeException failure)
+    {
+        if (scannerFactory == null) {
+            return;
+        }
+        try {
+            scannerFactory.close();
+        }
+        catch (RuntimeException closeFailure) {
+            failure.addSuppressed(closeFailure);
         }
     }
 

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceFragmentPageSource.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceFragmentPageSource.java
@@ -42,7 +42,17 @@ public class LanceFragmentPageSource
 
     public LanceFragmentPageSource(LanceTableHandle tableHandle, List<LanceColumnHandle> columns, List<String> filterProjectionColumns, List<Integer> fragments, Map<String, String> storageOptions, int readBatchSize, String userIdentity, LanceRuntime runtime)
     {
-        super(tableHandle, prepareColumns(columns), filterProjectionColumns, createScannerFactory(fragments, hasRowAddressColumn(columns), readBatchSize, runtime), storageOptions, userIdentity, runtime.getAllocator());
+        this(tableHandle, columns, filterProjectionColumns, Optional.of(fragments), storageOptions, readBatchSize, userIdentity, runtime);
+    }
+
+    public LanceFragmentPageSource(LanceTableHandle tableHandle, List<LanceColumnHandle> columns, List<String> filterProjectionColumns, LanceSplit split, Map<String, String> storageOptions, int readBatchSize, String userIdentity, LanceRuntime runtime)
+    {
+        this(tableHandle, columns, filterProjectionColumns, split.getFragmentIdsForScan(), storageOptions, readBatchSize, userIdentity, runtime);
+    }
+
+    private LanceFragmentPageSource(LanceTableHandle tableHandle, List<LanceColumnHandle> columns, List<String> filterProjectionColumns, Optional<List<Integer>> fragmentIds, Map<String, String> storageOptions, int readBatchSize, String userIdentity, LanceRuntime runtime)
+    {
+        super(tableHandle, prepareColumns(columns), filterProjectionColumns, createScannerFactory(fragmentIds, hasRowAddressColumn(columns), readBatchSize, runtime), storageOptions, userIdentity, runtime.getAllocator());
     }
 
     /**
@@ -69,9 +79,9 @@ public class LanceFragmentPageSource
         return columns.stream().anyMatch(col -> LANCE_ROW_ADDRESS.equals(col.name()));
     }
 
-    private static ScannerFactory createScannerFactory(List<Integer> fragments, boolean includeRowAddress, int readBatchSize, LanceRuntime runtime)
+    private static ScannerFactory createScannerFactory(Optional<List<Integer>> fragmentIds, boolean includeRowAddress, int readBatchSize, LanceRuntime runtime)
     {
-        return new FragmentScannerFactory(fragments, includeRowAddress, readBatchSize, runtime);
+        return new FragmentScannerFactory(fragmentIds, includeRowAddress, readBatchSize, runtime);
     }
 
     /**
@@ -83,7 +93,7 @@ public class LanceFragmentPageSource
     public static class FragmentScannerFactory
             implements ScannerFactory
     {
-        private final List<Integer> fragmentIds;
+        private final Optional<List<Integer>> fragmentIds;
         private final boolean includeRowAddress;
         private final int readBatchSize;
         private final LanceRuntime runtime;
@@ -92,7 +102,12 @@ public class LanceFragmentPageSource
 
         public FragmentScannerFactory(List<Integer> fragmentIds, boolean includeRowAddress, int readBatchSize, LanceRuntime runtime)
         {
-            this.fragmentIds = fragmentIds;
+            this(Optional.of(fragmentIds), includeRowAddress, readBatchSize, runtime);
+        }
+
+        public FragmentScannerFactory(Optional<List<Integer>> fragmentIds, boolean includeRowAddress, int readBatchSize, LanceRuntime runtime)
+        {
+            this.fragmentIds = fragmentIds.map(List::copyOf);
             this.includeRowAddress = includeRowAddress;
             this.readBatchSize = readBatchSize;
             this.runtime = runtime;
@@ -116,8 +131,8 @@ public class LanceFragmentPageSource
                 optionsBuilder.withRowAddress(true);
             }
 
-            log.debug("Opening dataset scanner for %d fragments with batchSize: %d, substraitFilter: %s, limit: %s, withRowAddress: %s, user: %s, version: %s",
-                    fragmentIds.size(),
+            log.debug("Opening dataset scanner for %s fragments with batchSize: %d, substraitFilter: %s, limit: %s, withRowAddress: %s, user: %s, version: %s",
+                    fragmentIds.map(ids -> Integer.toString(ids.size())).orElse("all"),
                     readBatchSize,
                     substraitFilter.isPresent() ? "present" : "none",
                     limit.isPresent() ? limit.getAsLong() : "none",

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSourceProvider.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSourceProvider.java
@@ -78,7 +78,7 @@ public class LancePageSourceProvider
                 lanceTableHandle,
                 lanceColumns,
                 filterProjectionColumns,
-                lanceSplit.getFragments(),
+                lanceSplit,
                 storageOptions,
                 lanceConfig.getReadBatchSize(),
                 userIdentity,

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceRuntime.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceRuntime.java
@@ -39,6 +39,7 @@ import org.lance.schema.LanceField;
 import org.lance.schema.LanceSchema;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,6 +57,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Central runtime component for Lance connector.
@@ -546,12 +548,39 @@ public class LanceRuntime
     public LanceScanner openDatasetScanner(String userIdentity, String tablePath, Long version,
             List<Integer> fragmentIds, ScanOptions scanOptions, Map<String, String> storageOptions)
     {
+        return openDatasetScanner(userIdentity, tablePath, version, Optional.of(fragmentIds), scanOptions, storageOptions);
+    }
+
+    public LanceScanner openDatasetScanner(String userIdentity, String tablePath, Long version,
+            Optional<List<Integer>> fragmentIds, ScanOptions scanOptions, Map<String, String> storageOptions)
+    {
         Dataset dataset = getDataset(userIdentity, tablePath, version, storageOptions);
 
-        ScanOptions.Builder scanBuilder = new ScanOptions.Builder(scanOptions)
-                .fragmentIds(fragmentIds);
+        return dataset.newScan(scanOptionsWithFragmentIds(scanOptions, fragmentIds));
+    }
 
-        return dataset.newScan(scanBuilder.build());
+    private static ScanOptions scanOptionsWithFragmentIds(ScanOptions scanOptions, Optional<List<Integer>> fragmentIds)
+    {
+        requireNonNull(scanOptions, "scanOptions is null");
+        requireNonNull(fragmentIds, "fragmentIds is null");
+
+        return new ScanOptions(
+                fragmentIds.map(List::copyOf),
+                scanOptions.getBatchSize(),
+                scanOptions.getColumns().map(List::copyOf),
+                scanOptions.getFilter(),
+                scanOptions.getSubstraitFilter().map(ByteBuffer::duplicate),
+                scanOptions.getLimit(),
+                scanOptions.getOffset(),
+                scanOptions.getNearest(),
+                scanOptions.getFullTextQuery(),
+                scanOptions.isPrefilter(),
+                scanOptions.isWithRowId(),
+                scanOptions.isWithRowAddress(),
+                scanOptions.getBatchReadahead(),
+                scanOptions.getColumnOrderings().map(List::copyOf),
+                scanOptions.isUseScalarIndex(),
+                scanOptions.getSubstraitAggregate().map(ByteBuffer::duplicate));
     }
 
     // ================== Lifecycle ==================

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplit.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplit.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.lance;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -22,8 +24,10 @@ import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -36,28 +40,84 @@ public class LanceSplit
     private static final int INSTANCE_SIZE = instanceSize(LanceSplit.class);
 
     private final List<Integer> fragments;
+    private final boolean allFragments;
 
     @JsonCreator
-    public LanceSplit(@JsonProperty("fragments") List<Integer> fragments)
+    public static LanceSplit fromJson(
+            @JsonProperty("fragments") List<Integer> fragments,
+            @JsonProperty("allFragments") Boolean allFragments)
     {
-        this.fragments = ImmutableList.copyOf(requireNonNull(fragments, "fragments is null"));
+        if (Boolean.TRUE.equals(allFragments)) {
+            checkArgument(fragments == null, "allFragments split cannot include explicit fragments");
+            return allFragments();
+        }
+        return new LanceSplit(fragments);
     }
 
-    @JsonProperty
+    public LanceSplit(List<Integer> fragments)
+    {
+        this(fragments, false);
+    }
+
+    private LanceSplit(List<Integer> fragments, boolean allFragments)
+    {
+        this.fragments = ImmutableList.copyOf(requireNonNull(fragments, "fragments is null"));
+        this.allFragments = allFragments;
+        checkArgument(!this.allFragments || this.fragments.isEmpty(), "allFragments split cannot include explicit fragments");
+    }
+
+    public static LanceSplit allFragments()
+    {
+        return new LanceSplit(List.of(), true);
+    }
+
+    @JsonIgnore
     public List<Integer> getFragments()
     {
         return fragments;
     }
 
+    @JsonProperty("fragments")
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public List<Integer> getJsonFragments()
+    {
+        if (allFragments) {
+            return null;
+        }
+        return fragments;
+    }
+
+    @JsonProperty("allFragments")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean isAllFragments()
+    {
+        return allFragments;
+    }
+
+    @JsonIgnore
+    public Optional<List<Integer>> getFragmentIdsForScan()
+    {
+        if (allFragments) {
+            return Optional.empty();
+        }
+        return Optional.of(fragments);
+    }
+
     @Override
     public String toString()
     {
-        return toStringHelper(this).add("fragments", fragments).toString();
+        return toStringHelper(this)
+                .add("fragments", fragments)
+                .add("allFragments", allFragments)
+                .toString();
     }
 
     @Override
     public Map<String, String> getSplitInfo()
     {
+        if (allFragments) {
+            return ImmutableMap.of("fragments", "ALL");
+        }
         return ImmutableMap.of("fragments", JOINER.join(fragments));
     }
 

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceSplitManager.java
@@ -57,6 +57,10 @@ public class LanceSplitManager
             return new FixedSplitSource(List.of(new LanceSplit(Collections.emptyList())));
         }
 
+        if (lanceTableHandle.getLimit().isPresent() && lanceTableHandle.hasFilter()) {
+            return new FixedSplitSource(List.of(LanceSplit.allFragments()));
+        }
+
         // Use storage options from handle, refreshing if expired
         Map<String, String> storageOptions = getEffectiveStorageOptions(lanceTableHandle);
         String userIdentity = session.getUser();

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
@@ -286,6 +286,26 @@ public class TestLanceConnectorTest
     }
 
     @Test
+    public void testFilteredLimitQueries()
+    {
+        assertThat(computeScalar("SELECT name FROM region WHERE regionkey = 2 LIMIT 10"))
+                .isEqualTo("ASIA");
+        assertThat(computeActual("SELECT name FROM region WHERE regionkey >= 0 LIMIT 1").getRowCount())
+                .isEqualTo(1);
+        assertThat(computeActual("SELECT name FROM region WHERE regionkey >= 0 LIMIT 10").getRowCount())
+                .isEqualTo(5);
+        assertThat(computeActual("SELECT name FROM region WHERE regionkey >= 0 LIMIT 100").getRowCount())
+                .isEqualTo(5);
+    }
+
+    @Test
+    public void testCountWithFilterAndLimitIsNotLimitShortCircuited()
+    {
+        assertThat(computeScalar("SELECT count(name) FROM region WHERE name > '' LIMIT 1"))
+                .isEqualTo(computeScalar("SELECT count(name) FROM region WHERE name > ''"));
+    }
+
+    @Test
     @Override
     public void testCharVarcharComparison()
     {

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceFragmentPageSource.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceFragmentPageSource.java
@@ -18,15 +18,26 @@ import com.google.common.io.Resources;
 import io.airlift.json.JsonCodec;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 import io.trino.testing.TestingConnectorSession;
+import org.apache.arrow.vector.ipc.ArrowReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.lance.Fragment;
+import org.lance.ipc.LanceScanner;
+import org.lance.ipc.ScanOptions;
 
+import java.io.IOException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +56,7 @@ public class TestLanceFragmentPageSource
     private LanceMetadata metadata;
     private LanceSplitManager splitManager;
     private LanceRuntime runtime;
+    private LanceConfig lanceConfig;
 
     @BeforeEach
     public void setUp()
@@ -54,7 +66,7 @@ public class TestLanceFragmentPageSource
         assertThat(lanceURL)
                 .describedAs("example db is null")
                 .isNotNull();
-        LanceConfig lanceConfig = new LanceConfig()
+        lanceConfig = new LanceConfig()
                 .setSingleLevelNs(true);  // example_db is flat (tables at root)
         Map<String, String> catalogProperties = ImmutableMap.of("lance.root", lanceURL.toString());
         runtime = new LanceRuntime(lanceConfig, catalogProperties);
@@ -62,6 +74,91 @@ public class TestLanceFragmentPageSource
         JsonCodec<LanceMergeCommitData> mergeCommitDataCodec = JsonCodec.jsonCodec(LanceMergeCommitData.class);
         this.metadata = new LanceMetadata(runtime, lanceConfig, commitTaskDataCodec, mergeCommitDataCodec);
         this.splitManager = new LanceSplitManager(runtime);
+    }
+
+    @Test
+    public void testDatasetScanWithoutFragmentIdsRespectsLimit()
+            throws Exception
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+        ScanOptions scanOptions = new ScanOptions.Builder()
+                .limit(3)
+                .build();
+
+        try (LanceScanner scanner = runtime.openDatasetScanner(
+                TestingConnectorSession.SESSION.getUser(),
+                tableHandle.getTablePath(),
+                tableHandle.getDatasetVersion(),
+                Optional.empty(),
+                scanOptions,
+                Collections.emptyMap())) {
+            assertThat(readAllRows(scanner)).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void testDatasetScanWithoutFragmentIdsClearsScanOptionsFragmentIds()
+            throws Exception
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+        List<Fragment> fragments = runtime.getFragments(
+                TestingConnectorSession.SESSION.getUser(),
+                tableHandle.getTablePath(),
+                tableHandle.getDatasetVersion(),
+                Collections.emptyMap());
+        ScanOptions scanOptions = new ScanOptions.Builder()
+                .fragmentIds(List.of(fragments.get(0).getId()))
+                .build();
+
+        try (LanceScanner scanner = runtime.openDatasetScanner(
+                TestingConnectorSession.SESSION.getUser(),
+                tableHandle.getTablePath(),
+                tableHandle.getDatasetVersion(),
+                Optional.empty(),
+                scanOptions,
+                Collections.emptyMap())) {
+            assertThat(readAllRows(scanner)).isEqualTo(4);
+        }
+    }
+
+    @Test
+    public void testAllFragmentsSplitAppliesFilterAndLimitThroughPageSource()
+            throws Exception
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+        List<LanceColumnHandle> allColumns = runtime.getColumnHandleList(
+                TestingConnectorSession.SESSION.getUser(),
+                tableHandle.getTablePath(),
+                tableHandle.getDatasetVersion(),
+                Collections.emptyMap());
+        LanceColumnHandle colX = allColumns.stream()
+                .filter(column -> column.name().equals("x"))
+                .findFirst()
+                .orElseThrow();
+        LanceTableHandle filteredLimitHandle = tableHandle
+                .withLimit(1)
+                .withSubstraitFilter(greaterThanOrEqualFilter(allColumns, colX, 2), List.of(colX.name()));
+        LancePageSourceProvider pageSourceProvider = new LancePageSourceProvider(runtime, lanceConfig);
+
+        try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(
+                null,
+                TestingConnectorSession.SESSION,
+                LanceSplit.allFragments(),
+                filteredLimitHandle,
+                List.of(colX),
+                null)) {
+            Page page = pageSource.getNextPage();
+            assertThat(page).isNotNull();
+            assertThat(page.getChannelCount()).isEqualTo(1);
+            assertThat(page.getPositionCount()).isEqualTo(1);
+            assertThat(BIGINT.getLong(page.getBlock(0), 0)).isGreaterThanOrEqualTo(2L);
+
+            assertThat(pageSource.getNextPage()).isNull();
+            assertThat(pageSource.isFinished()).isTrue();
+        }
     }
 
     @Test
@@ -183,5 +280,31 @@ public class TestLanceFragmentPageSource
             assertThat(BIGINT.getLong(xBlock, 0)).isEqualTo(0L);
             assertThat(BIGINT.getLong(xBlock, 1)).isEqualTo(1L);
         }
+    }
+
+    private static long readAllRows(LanceScanner scanner)
+            throws IOException
+    {
+        long rows = 0;
+        try (ArrowReader reader = scanner.scanBatches()) {
+            while (reader.loadNextBatch()) {
+                rows += reader.getVectorSchemaRoot().getRowCount();
+            }
+        }
+        return rows;
+    }
+
+    private static byte[] greaterThanOrEqualFilter(List<LanceColumnHandle> allColumns, LanceColumnHandle column, long value)
+    {
+        TupleDomain<LanceColumnHandle> domain = TupleDomain.withColumnDomains(
+                Map.of(column, Domain.create(
+                        ValueSet.ofRanges(Range.greaterThanOrEqual(column.trinoType(), value)), false)));
+        ByteBuffer buffer = SubstraitExpressionBuilder.tupleDomainToSubstrait(
+                        domain, allColumns, LanceMetadata.buildPositionalOrdinals(allColumns))
+                .orElseThrow();
+        ByteBuffer copy = buffer.duplicate();
+        byte[] bytes = new byte[copy.remaining()];
+        copy.get(bytes);
+        return bytes;
     }
 }

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceSplitManager.java
@@ -23,14 +23,17 @@ import io.trino.testing.TestingConnectorSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.lance.Fragment;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 
 @TestInstance(PER_METHOD)
@@ -40,6 +43,7 @@ public class TestLanceSplitManager
 
     private LanceMetadata metadata;
     private LanceSplitManager splitManager;
+    private TrackingLanceRuntime runtime;
 
     @BeforeEach
     public void setUp()
@@ -52,7 +56,7 @@ public class TestLanceSplitManager
         LanceConfig lanceConfig = new LanceConfig()
                 .setSingleLevelNs(true);
         Map<String, String> catalogProperties = ImmutableMap.of("lance.root", lanceURL.toString());
-        LanceRuntime runtime = new LanceRuntime(lanceConfig, catalogProperties);
+        runtime = new TrackingLanceRuntime(lanceConfig, catalogProperties);
         JsonCodec<LanceCommitTaskData> commitTaskDataCodec = JsonCodec.jsonCodec(LanceCommitTaskData.class);
         JsonCodec<LanceMergeCommitData> mergeCommitDataCodec = JsonCodec.jsonCodec(LanceMergeCommitData.class);
         this.metadata = new LanceMetadata(runtime, lanceConfig, commitTaskDataCodec, mergeCommitDataCodec);
@@ -149,13 +153,12 @@ public class TestLanceSplitManager
     }
 
     @Test
-    public void testLimitWithFilterDoesNotCoalesce()
+    public void testLimitWithFilterUsesAllFragmentsSplit()
             throws ExecutionException, InterruptedException
     {
         LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
                 TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
 
-        // Apply both a LIMIT and a filter — coalescing should NOT apply
         LanceTableHandle withLimitAndFilter = tableHandle
                 .withLimit(1)
                 .withSubstraitFilter(new byte[] {0x01}, List.of("x"));
@@ -163,11 +166,81 @@ public class TestLanceSplitManager
                 null, TestingConnectorSession.SESSION, withLimitAndFilter, null, null);
         List<LanceSplit> splits = getAllSplits(splitSource);
 
-        // With a filter present, each fragment gets its own split
-        assertThat(splits).hasSize(2);
-        for (LanceSplit split : splits) {
-            assertThat(split.getFragments()).hasSize(1);
-        }
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).isAllFragments()).isTrue();
+        assertThat(splits.get(0).getFragments()).isEmpty();
+    }
+
+    @Test
+    public void testFilteredLimitDoesNotEnumerateFragments()
+            throws ExecutionException, InterruptedException
+    {
+        LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
+                TestingConnectorSession.SESSION, TEST_TABLE_1, Optional.empty(), Optional.empty());
+
+        LanceTableHandle withLimitAndFilter = tableHandle
+                .withLimit(10)
+                .withSubstraitFilter(new byte[] {0x01}, List.of("x"));
+        runtime.failOnGetFragments();
+
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                null, TestingConnectorSession.SESSION, withLimitAndFilter, null, null);
+        List<LanceSplit> splits = getAllSplits(splitSource);
+
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).isAllFragments()).isTrue();
+    }
+
+    @Test
+    public void testAllFragmentsSplit()
+    {
+        LanceSplit split = LanceSplit.allFragments();
+
+        assertThat(split.isAllFragments()).isTrue();
+        assertThat(split.getFragments()).isEmpty();
+        assertThat(split.getSplitInfo()).containsEntry("fragments", "ALL");
+
+        JsonCodec<LanceSplit> codec = JsonCodec.jsonCodec(LanceSplit.class);
+        String json = codec.toJson(split);
+        assertThat(json)
+                .contains("\"fragments\"")
+                .contains("null")
+                .contains("\"allFragments\"")
+                .contains("true")
+                .doesNotContain("[]");
+
+        LanceSplit copy = codec.fromJson(json);
+        assertThat(copy.isAllFragments()).isTrue();
+        assertThat(copy.getFragments()).isEmpty();
+    }
+
+    @Test
+    public void testLanceSplitJsonCompatibility()
+    {
+        JsonCodec<LanceSplit> codec = JsonCodec.jsonCodec(LanceSplit.class);
+
+        LanceSplit legacySplit = codec.fromJson("{\"fragments\":[1,2]}");
+        assertThat(legacySplit.isAllFragments()).isFalse();
+        assertThat(legacySplit.getFragments()).containsExactly(1, 2);
+        assertThat(codec.toJson(legacySplit))
+                .contains("\"fragments\"")
+                .contains("1")
+                .contains("2")
+                .doesNotContain("allFragments");
+
+        LanceSplit allFragmentsSplit = codec.fromJson("{\"fragments\":null,\"allFragments\":true}");
+        assertThat(allFragmentsSplit.isAllFragments()).isTrue();
+        assertThat(allFragmentsSplit.getFragments()).isEmpty();
+
+        assertThatThrownBy(() -> new LanceSplit((List<Integer>) null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("fragments is null");
+        assertThatThrownBy(() -> codec.fromJson("{}"))
+                .hasRootCauseMessage("fragments is null");
+        assertThatThrownBy(() -> codec.fromJson("{\"fragments\":null}"))
+                .hasRootCauseMessage("fragments is null");
+        assertThatThrownBy(() -> codec.fromJson("{\"fragments\":[1],\"allFragments\":true}"))
+                .hasRootCauseMessage("allFragments split cannot include explicit fragments");
     }
 
     @Test
@@ -213,9 +286,41 @@ public class TestLanceSplitManager
     private static List<LanceSplit> getAllSplits(ConnectorSplitSource splitSource)
             throws ExecutionException, InterruptedException
     {
-        ConnectorSplitSource.ConnectorSplitBatch batch = splitSource.getNextBatch(100).get();
-        return batch.getSplits().stream()
-                .map(LanceSplit.class::cast)
-                .toList();
+        List<LanceSplit> splits = new ArrayList<>();
+        boolean lastBatch;
+        do {
+            ConnectorSplitSource.ConnectorSplitBatch batch = splitSource.getNextBatch(100).get();
+            batch.getSplits().stream()
+                    .map(LanceSplit.class::cast)
+                    .forEach(splits::add);
+            lastBatch = batch.isNoMoreSplits();
+        }
+        while (!lastBatch);
+        return splits;
+    }
+
+    private static class TrackingLanceRuntime
+            extends LanceRuntime
+    {
+        private boolean failOnGetFragments;
+
+        public TrackingLanceRuntime(LanceConfig config, Map<String, String> namespaceProperties)
+        {
+            super(config, namespaceProperties);
+        }
+
+        public void failOnGetFragments()
+        {
+            failOnGetFragments = true;
+        }
+
+        @Override
+        public List<Fragment> getFragments(String userIdentity, String tablePath, Long version, Map<String, String> storageOptions)
+        {
+            if (failOnGetFragments) {
+                throw new AssertionError("filtered LIMIT split generation should not enumerate fragments");
+            }
+            return super.getFragments(userIdentity, tablePath, version, storageOptions);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Plan filtered LIMIT queries as one dataset-level split instead of enumerating fragments.
- Let the scan omit fragment ids so Lance can apply the pushed filter and LIMIT across the dataset.
- Add coverage for filtered limits, split JSON compatibility, and ScanOptions behavior.

## Testing
- `./mvnw -pl plugin/trino-lance -Dtest=TestLanceSplitManager,TestLanceFragmentPageSource,TestLanceConnectorTest test`

Local measurement: split generation only. On a local TPC-DS SF100 Lance dataset, the old path created 210 splits with p50 1.810 ms; the new path creates 1 split with p50 0.002 ms.

<details>
<summary>Local benchmark used for measurement</summary>

This benchmark was used locally for the measurement above and is not part of this PR diff.

```java
/*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
package io.trino.plugin.lance;

import com.google.common.collect.ImmutableMap;
import io.airlift.json.JsonCodec;
import io.trino.spi.connector.ConnectorSplitSource;
import io.trino.spi.connector.SchemaTableName;
import io.trino.spi.predicate.Domain;
import io.trino.spi.predicate.Range;
import io.trino.spi.predicate.TupleDomain;
import io.trino.spi.predicate.ValueSet;
import io.trino.testing.MaterializedResult;
import io.trino.testing.QueryRunner;
import io.trino.testing.TestingConnectorSession;
import org.junit.jupiter.api.Test;
import org.lance.Fragment;

import java.nio.ByteBuffer;
import java.nio.file.Files;
import java.nio.file.Path;
import java.util.ArrayList;
import java.util.Collections;
import java.util.List;
import java.util.Locale;
import java.util.Map;
import java.util.Optional;
import java.util.concurrent.Callable;

import static org.junit.jupiter.api.Assumptions.assumeTrue;

public class BenchmarkFilteredLimit
{
    private static final String DEFAULT_TABLE = "inventory";
    private static final String DEFAULT_COLUMNS = "inv_date_sk, inv_item_sk";
    private static final String DEFAULT_FILTER_COLUMN = "inv_date_sk";

    @Test
    public void benchmarkFilteredLimit()
            throws Exception
    {
        assumeTrue(Boolean.getBoolean("lance.benchmark.filtered-limit"),
                "Set -Dlance.benchmark.filtered-limit=true to run this benchmark");

        String rootProperty = System.getProperty("lance.benchmark.root");
        if (rootProperty == null || rootProperty.isBlank()) {
            throw new IllegalArgumentException("Set -Dlance.benchmark.root=/path/to/lance/root to run this benchmark");
        }
        Path root = Path.of(rootProperty);
        if (!Files.isDirectory(root)) {
            throw new IllegalArgumentException("Benchmark root must be an existing directory: " + root);
        }
        String rootUri = root.toUri().toString();
        String table = System.getProperty("lance.benchmark.table", DEFAULT_TABLE);
        String filterColumn = System.getProperty("lance.benchmark.filter-column", DEFAULT_FILTER_COLUMN);
        long limit = Long.getLong("lance.benchmark.limit", 10);
        if (limit <= 0) {
            throw new IllegalArgumentException("lance.benchmark.limit must be greater than 0");
        }
        String columns = System.getProperty("lance.benchmark.columns", DEFAULT_COLUMNS);
        String query = System.getProperty("lance.benchmark.query",
                format("SELECT %s FROM %s WHERE %s > 0 LIMIT %d", columns, table, filterColumn, limit));
        int warmupIterations = Integer.getInteger("lance.benchmark.warmup", 3);
        int measureIterations = Integer.getInteger("lance.benchmark.iterations", 10);
        if (warmupIterations < 0) {
            throw new IllegalArgumentException("lance.benchmark.warmup must be greater than or equal to 0");
        }
        if (measureIterations <= 0) {
            throw new IllegalArgumentException("lance.benchmark.iterations must be greater than 0");
        }

        System.out.println();
        System.out.println("Filtered LIMIT benchmark");
        System.out.println(format("root: %s", root));
        System.out.println(format("table: %s", table));
        System.out.println(format("query: %s", query));
        System.out.println(format("warmup: %d, iterations: %d", warmupIterations, measureIterations));
        System.out.println();

        runSplitGenerationBenchmark(rootUri, table, filterColumn, limit, warmupIterations, measureIterations);
        runQueryBenchmark(rootUri, query, warmupIterations, measureIterations);
    }

    private static void runSplitGenerationBenchmark(String rootUri, String table, String filterColumn, long limit, int warmupIterations, int measureIterations)
            throws Exception
    {
        LanceConfig lanceConfig = new LanceConfig()
                .setSingleLevelNs(true);
        Map<String, String> catalogProperties = ImmutableMap.of("lance.root", rootUri);
        try (LanceRuntime runtime = new LanceRuntime(lanceConfig, catalogProperties)) {
            JsonCodec<LanceCommitTaskData> commitTaskDataCodec = JsonCodec.jsonCodec(LanceCommitTaskData.class);
            JsonCodec<LanceMergeCommitData> mergeCommitDataCodec = JsonCodec.jsonCodec(LanceMergeCommitData.class);
            LanceMetadata metadata = new LanceMetadata(runtime, lanceConfig, commitTaskDataCodec, mergeCommitDataCodec);
            LanceSplitManager splitManager = new LanceSplitManager(runtime);

            LanceTableHandle tableHandle = (LanceTableHandle) metadata.getTableHandle(
                    TestingConnectorSession.SESSION,
                    new SchemaTableName("default", table),
                    Optional.empty(),
                    Optional.empty());
            List<LanceColumnHandle> allColumns = runtime.getColumnHandleList(
                    TestingConnectorSession.SESSION.getUser(),
                    tableHandle.getTablePath(),
                    tableHandle.getDatasetVersion(),
                    tableHandle.getStorageOptions());
            LanceTableHandle filteredLimitHandle = tableHandle
                    .withLimit(limit)
                    .withSubstraitFilter(greaterThanFilter(allColumns, filterColumn, 0), List.of(filterColumn));

            BenchmarkResult oldSplitGeneration = measure(
                    "old split generation equivalent",
                    warmupIterations,
                    measureIterations,
                    () -> {
                        List<Fragment> fragments = runtime.getFragments(
                                TestingConnectorSession.SESSION.getUser(),
                                tableHandle.getTablePath(),
                                tableHandle.getDatasetVersion(),
                                tableHandle.getStorageOptions());
                        List<LanceSplit> splits = new ArrayList<>(fragments.size());
                        for (Fragment fragment : fragments) {
                            splits.add(new LanceSplit(List.of(fragment.getId())));
                        }
                        return (long) splits.size();
                    });

            BenchmarkResult pr2SplitGeneration = measure(
                    "pr2 split generation",
                    warmupIterations,
                    measureIterations,
                    () -> {
                        try (ConnectorSplitSource splitSource = splitManager.getSplits(
                                null,
                                TestingConnectorSession.SESSION,
                                filteredLimitHandle,
                                null,
                                null)) {
                            ConnectorSplitSource.ConnectorSplitBatch batch = splitSource.getNextBatch(1_000_000).get();
                            return (long) batch.getSplits().size();
                        }
                    });

            printResult(oldSplitGeneration, "splits");
            printResult(pr2SplitGeneration, "splits");
            printRatio("split generation p50 speedup", oldSplitGeneration.p50Nanos(), pr2SplitGeneration.p50Nanos());
        }
    }

    private static void runQueryBenchmark(String rootUri, String query, int warmupIterations, int measureIterations)
            throws Exception
    {
        try (QueryRunner queryRunner = LanceQueryRunner.builder()
                .addConnectorProperty("lance.root", rootUri)
                .addConnectorProperty("lance.single_level_ns", "true")
                .build()) {
            BenchmarkResult queryExecution = measure(
                    "query execution",
                    warmupIterations,
                    measureIterations,
                    () -> {
                        MaterializedResult result = queryRunner.execute(query);
                        return (long) result.getRowCount();
                    });

            printResult(queryExecution, "rows");
        }
    }

    private static BenchmarkResult measure(String name, int warmupIterations, int measureIterations, Callable<Long> callable)
            throws Exception
    {
        long value = 0;
        for (int i = 0; i < warmupIterations; i++) {
            value = callable.call();
        }

        List<Long> timings = new ArrayList<>();
        for (int i = 0; i < measureIterations; i++) {
            long start = System.nanoTime();
            value = callable.call();
            timings.add(System.nanoTime() - start);
        }
        return new BenchmarkResult(name, timings, value);
    }

    private static void printResult(BenchmarkResult result, String valueUnit)
    {
        System.out.println(format(
                "%-32s value=%d %s avg=%.3f ms p50=%.3f ms p95=%.3f ms min=%.3f ms max=%.3f ms",
                result.name(),
                result.value(),
                valueUnit,
                toMillis(result.avgNanos()),
                toMillis(result.p50Nanos()),
                toMillis(result.p95Nanos()),
                toMillis(result.minNanos()),
                toMillis(result.maxNanos())));
    }

    private static void printRatio(String name, long baselineNanos, long candidateNanos)
    {
        if (candidateNanos == 0) {
            System.out.println(format("%s: candidate rounded to 0 ns", name));
            return;
        }
        System.out.println(format("%s: %.2fx", name, (double) baselineNanos / candidateNanos));
        System.out.println();
    }

    private static byte[] greaterThanFilter(List<LanceColumnHandle> allColumns, String columnName, long value)
    {
        LanceColumnHandle column = allColumns.stream()
                .filter(handle -> handle.name().equals(columnName))
                .findFirst()
                .orElseThrow(() -> new IllegalArgumentException("Filter column not found: " + columnName));
        TupleDomain<LanceColumnHandle> domain = TupleDomain.withColumnDomains(
                Map.of(column, Domain.create(
                        ValueSet.ofRanges(Range.greaterThan(column.trinoType(), value)), false)));
        ByteBuffer buffer = SubstraitExpressionBuilder.tupleDomainToSubstrait(
                        domain, allColumns, LanceMetadata.buildPositionalOrdinals(allColumns))
                .orElseThrow(() -> new IllegalArgumentException("Unable to build Substrait filter for column: " + columnName));
        ByteBuffer copy = buffer.duplicate();
        byte[] bytes = new byte[copy.remaining()];
        copy.get(bytes);
        return bytes;
    }

    private static String format(String format, Object... args)
    {
        return String.format(Locale.US, format, args);
    }

    private static double toMillis(double nanos)
    {
        return nanos / 1_000_000.0;
    }

    private record BenchmarkResult(String name, List<Long> timingsNanos, long value)
    {
        private BenchmarkResult
        {
            timingsNanos = List.copyOf(timingsNanos);
        }

        private double avgNanos()
        {
            return timingsNanos.stream()
                    .mapToLong(Long::longValue)
                    .average()
                    .orElse(0);
        }

        private long p50Nanos()
        {
            return percentile(0.50);
        }

        private long p95Nanos()
        {
            return percentile(0.95);
        }

        private long minNanos()
        {
            return timingsNanos.stream()
                    .mapToLong(Long::longValue)
                    .min()
                    .orElse(0);
        }

        private long maxNanos()
        {
            return timingsNanos.stream()
                    .mapToLong(Long::longValue)
                    .max()
                    .orElse(0);
        }

        private long percentile(double percentile)
        {
            if (timingsNanos.isEmpty()) {
                return 0;
            }
            List<Long> sorted = new ArrayList<>(timingsNanos);
            Collections.sort(sorted);
            int index = Math.max(0, (int) Math.ceil(sorted.size() * percentile) - 1);
            return sorted.get(index);
        }
    }
}
```

</details>

Closes #141