### PR TITLE
chore: update lance dependency to v8.0.0-beta.8

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.8` in `plugin/trino-lance/pom.xml`.
- Confirmed the tagged Lance Java POM keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency changes were needed.

## Verification
- Checked the requested Maven Central POM URL; `8.0.0-beta.8` was not available from Central at verification time.
- Installed `org.lance:lance-core:8.0.0-beta.8` locally from `lance-format/lance` tag `refs/tags/v8.0.0-beta.8` to verify this repo.
- Ran `make lint` successfully.
- Ran `make compile` successfully.

Triggering tag: `refs/tags/v8.0.0-beta.8`
