### PR TITLE
chore: update lance dependency to v8.0.0-beta.9

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.9`.
- Confirmed the `v8.0.0-beta.9` Lance tag's `java/pom.xml` keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency change is needed.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet list `org.lance:lance-core:8.0.0-beta.9` during verification, so the tagged Lance Java artifact was installed locally from `lance-format/lance` at `refs/tags/v8.0.0-beta.9` before rerunning the checks.

Triggering tag: [`refs/tags/v8.0.0-beta.9`](https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.9)
