### PR TITLE
chore: update lance dependency to v8.0.0-beta.10

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.10`.
- Checked the `v8.0.0-beta.10` Lance Java POM and left `lance-namespace-core` and `lance-namespace-apache-client` at the compatible `0.7.7` versions.
- Triggering tag: refs/tags/v8.0.0-beta.10 (https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.10)

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:8.0.0-beta.10` during this runner session, so the exact tagged Lance Java artifact was installed locally from `lance-format/lance` tag `v8.0.0-beta.10` before running verification.
