### PR TITLE
chore: update lance dependency to v8.0.0-beta.11

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.11</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.11`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance `v8.0.0-beta.11` source POM.
- Triggering tag: refs/tags/v8.0.0-beta.11

## Verification
- `make lint`
- `make compile`

Note: `org.lance:lance-core:8.0.0-beta.11` was not yet resolvable from Maven Central on this runner, so the tagged Lance Java artifact was installed into the local Maven cache from `lance-format/lance` at `v8.0.0-beta.11` before running verification.
