### PR TITLE
chore: update lance dependency to v8.0.0-beta.12

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

- Update `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.12`.
- Confirmed the tagged Lance Java POM keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency changes were needed.
- Triggering tag: [`refs/tags/v8.0.0-beta.12`](https://github.com/lance-format/lance/tree/v8.0.0-beta.12)

## Verification

- `make lint` passed.
- `make compile` passed.

Note: `org.lance:lance-core:8.0.0-beta.12` was not available from Maven Central during verification, so I installed the artifact locally from the `v8.0.0-beta.12` Lance tag before rerunning the checks.
