### PR TITLE
chore: update lance dependency to v8.0.0-beta.13

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.13`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance `v8.0.0-beta.13` Java POM.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet expose `org.lance:lance-core:8.0.0-beta.13` during local verification, so I installed the artifact locally from the Lance source tag before running the checks.

Triggering tag: https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.13 (`refs/tags/v8.0.0-beta.13`)
