### PR TITLE
chore: update lance dependency to v8.0.0-beta.14

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.14`.
- Checked the Lance `v8.0.0-beta.14` Java POM; `lance-namespace-core` and `lance-namespace-apache-client` remain compatible at `0.7.7`.
- Triggering tag: https://github.com/lancedb/lance/tree/refs/tags/v8.0.0-beta.14

## Verification
- `make lint` passed.
- `make compile` passed with existing deprecation warnings.

Note: Maven Central did not yet serve `org.lance:lance-core:8.0.0-beta.14` on this runner, so verification used a local Maven install of `lance-core` built from `refs/tags/v8.0.0-beta.14` with JNI skipped for local dependency resolution.
