### PR TITLE
chore: update lance dependency to v8.0.0-beta.15

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.15</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.15` in `plugin/trino-lance/pom.xml`.
- Confirmed the Lance `v8.0.0-beta.15` Java POM keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency changes were needed.
- Triggering tag: refs/tags/v8.0.0-beta.15

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:8.0.0-beta.15` during this runner session, so I installed the tagged Lance Java artifact into the local Maven cache from `lance-format/lance` tag `v8.0.0-beta.15` before running verification.
