### PR TITLE
chore: update lance dependency to v8.0.0-beta.16

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.16</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.16`.
- Leaves `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance Java POM for the triggering tag.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet expose `org.lance:lance-core:8.0.0-beta.16` during runner verification, so the tagged Lance Java artifact was installed locally from `lance-format/lance` at `refs/tags/v8.0.0-beta.16` before running the checks.

Triggering tag: `refs/tags/v8.0.0-beta.16`
