### PR TITLE
chore: update lance dependency to v8.0.0-beta.17

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.17` in `plugin/trino-lance/pom.xml`.
- Checked the upstream Lance `v8.0.0-beta.17` Java POM and kept `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`.
- Triggering tag: refs/tags/v8.0.0-beta.17

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:8.0.0-beta.17` during the first lint attempt, so the tagged upstream `lance-core` artifact was installed locally from `lance-format/lance` tag `v8.0.0-beta.17` to complete verification.
