### PR TITLE
chore: update lance dependency to v8.0.0-beta.18

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.18</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.18` in `plugin/trino-lance/pom.xml`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance `v8.0.0-beta.18` Java POM.
- Triggering tag: https://github.com/lancedb/lance/tree/refs/tags/v8.0.0-beta.18

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet publish `org.lance:lance-core:8.0.0-beta.18` during local verification, so I checked out `lancedb/lance` at `refs/tags/v8.0.0-beta.18` and installed that Java artifact locally before running the checks above.
