### PR TITLE
chore: update lance dependency to v8.0.0-beta.19

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0-beta.19</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `7.0.0` to `8.0.0-beta.19`.
- Confirmed `lance-namespace-core` and `lance-namespace-apache-client` remain compatible at `0.7.7` from the upstream Lance Java POM for this tag.
- Triggering tag: [refs/tags/v8.0.0-beta.19](https://github.com/lance-format/lance/tree/refs/tags/v8.0.0-beta.19)

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:8.0.0-beta.19` on this runner, so verification used a local Maven install of the exact artifact built from the upstream `refs/tags/v8.0.0-beta.19` tag.
