### PR TITLE
chore: update lance dependency to v9.0.0-beta.1

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.1`.
- Checked the published `lance-core` POM for `9.0.0-beta.1`; `lance-namespace-core` and `lance-namespace-apache-client` remain compatible at `0.7.7`.

## Verification
- `make lint`
- `make compile`

Triggering tag: [refs/tags/v9.0.0-beta.1](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.1)
