### PR TITLE
chore: update lance dependency to v9.0.0-beta.2

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.2`.
- Verified `lance-core` 9.0.0-beta.2 still declares `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency updates were needed.
- Triggering tag: refs/tags/v9.0.0-beta.2

## Verification
- `make lint`
- `make compile`
