### PR TITLE
chore: update lance dependency to v9.0.0-beta.3

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.3` in `plugin/trino-lance/pom.xml`.
- Checked the Lance `v9.0.0-beta.3` source POM and kept `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`.
- Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v9.0.0-beta.3 (`refs/tags/v9.0.0-beta.3`).

## Verification
- `make lint`
- `make compile`

Note: `org.lance:lance-core:9.0.0-beta.3` was not yet available from Maven Central on this runner, so the exact tag was built and installed locally from `lance-format/lance` before running verification.
