### PR TITLE
chore: update lance dependency to v9.0.0-beta.4

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.4`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance `v9.0.0-beta.4` source POM compatibility.

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:9.0.0-beta.4` during verification, so the exact `refs/tags/v9.0.0-beta.4` Lance source tag was installed into the runner's local Maven cache before running the checks.

Triggering tag: [`refs/tags/v9.0.0-beta.4`](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.4)
