### PR TITLE
chore: update lance dependency to v9.0.0-beta.5

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.5`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance `v9.0.0-beta.5` source POM.
- Triggering tag: refs/tags/v9.0.0-beta.5

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet expose `org.lance:lance-core:9.0.0-beta.5` during this run, so I checked out `lance-format/lance` at `v9.0.0-beta.5` and installed the tagged `java` artifact locally before running verification.
