### PR TITLE
chore: update lance dependency to v9.0.0-beta.6

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.6`.
- Confirmed the tagged Lance source keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency changes were needed.

## Verification

- `make lint` passed.
- `make compile` passed.

Note: Maven Central did not yet have `org.lance:lance-core:9.0.0-beta.6` available at verification time, so I installed `lance-core` locally from the upstream tag before running the checks.

Triggering tag: [`refs/tags/v9.0.0-beta.6`](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.6)
