### PR TITLE
chore: update lance dependency to v9.0.0-beta.7

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

- Updates `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.7`.
- Keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance Java POM for the triggering tag.
- Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v9.0.0-beta.7

## Verification

- `make lint` passed.
- `make compile` passed.

Note: Maven Central did not yet serve `org.lance:lance-core:9.0.0-beta.7` during validation, so I installed the artifact locally from the upstream `refs/tags/v9.0.0-beta.7` source checkout before running the checks.
