### PR TITLE
chore: update lance dependency to v9.0.0-beta.8

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.8` in `plugin/trino-lance/pom.xml`.
- Confirmed the `v9.0.0-beta.8` source POM keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency changes were needed.
- Triggering tag: refs/tags/v9.0.0-beta.8

## Verification
- `make lint`
- `make compile`

Note: `org.lance:lance-core:9.0.0-beta.8` was not yet available from Maven Central during verification, so the tagged `lance-format/lance` Java artifact was installed into the runner's local Maven cache from `refs/tags/v9.0.0-beta.8` before running the checks.
