### PR TITLE
chore: update lance dependency to v9.0.0-beta.10

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.10`.
- Checked the tagged Lance Java POM for namespace compatibility; `lance-namespace-core` and `lance-namespace-apache-client` remain compatible at `0.7.7`.

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central had not yet synced `org.lance:lance-core:9.0.0-beta.10` when this was prepared, so the tagged Lance Java module was installed locally from `refs/tags/v9.0.0-beta.10` to complete validation on this runner.

Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v9.0.0-beta.10
