### PR TITLE
chore: update lance dependency to v9.0.0-beta.11

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.11</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.11` in `plugin/trino-lance/pom.xml`.
- Checked the Lance tag POM for compatibility; `lance-namespace-core` and `lance-namespace-apache-client` remain compatible at `0.7.7`.
- Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v9.0.0-beta.11

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not yet resolve `org.lance:lance-core:9.0.0-beta.11` during this runner session, so I installed the artifact locally from `lance-format/lance` at `refs/tags/v9.0.0-beta.11` before running verification.
