### PR TITLE
chore: update lance dependency to v9.0.0-beta.12

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.12`.
- Checked the tagged Lance source POM for compatibility; `lance-namespace-core` and `lance-namespace-apache-client` remain compatible at `0.7.7`.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.12 (`refs/tags/v9.0.0-beta.12`)

## Verification
- `make lint` failed during Maven dependency resolution because `org.lance:lance-core:9.0.0-beta.12` is not available from Maven Central yet.
- `make compile` failed for the same Maven dependency-resolution issue.
