### PR TITLE
chore: update lance dependency to v9.0.0-beta.13

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.13`.
- Keep `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the Lance `refs/tags/v9.0.0-beta.13` source POM.

## Verification
- Checked Maven Central metadata and the tag source POM for compatible dependency versions.
- Installed the tagged `org.lance:lance-core:9.0.0-beta.13` artifact locally from `lance-format/lance` because Maven Central did not yet resolve that artifact on this runner.
- `make lint`
- `make compile`

Triggering tag: `refs/tags/v9.0.0-beta.13`
