### PR TITLE
chore: update lance dependency to v9.0.0-beta.14

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Updates `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.14`.
- Keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, matching the upstream Lance `v9.0.0-beta.14` Java POM.
- Triggering tag: [`refs/tags/v9.0.0-beta.14`](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.14)

## Verification
- `make lint`
- `make compile`

Note: `org.lance:lance-core:9.0.0-beta.14` was not yet visible in Maven Central during this run, so the checks were run after installing the upstream tagged Lance Java artifact into the runner's local Maven cache.
