### PR TITLE
chore: update lance dependency to v9.0.0-beta.15

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.15</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.15`.
- Confirmed the tagged Lance Java POM keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so those dependencies remain unchanged.
- Triggering tag: [refs/tags/v9.0.0-beta.15](https://github.com/lance-format/lance/tree/refs/tags/v9.0.0-beta.15)

## Verification
- `make lint` passes.
- `make compile` passes.

Note: Maven Central did not yet resolve `org.lance:lance-core:9.0.0-beta.15` during this run, so I installed the tagged Lance Java artifact into the runner's local Maven cache from source before rerunning the checks.
