### PR TITLE
Expose missing blob_columns and vector_columns table properties

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -88,6 +88,7 @@ import org.lance.namespace.model.NamespaceExistsRequest;
 import org.lance.operation.Append;
 import org.lance.operation.Overwrite;
 import org.lance.operation.Update;
+import org.lance.schema.LanceSchema;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -376,11 +377,13 @@ public class LanceMetadata
         try {
             Map<String, String> storageOptions = getEffectiveStorageOptions(lanceTableHandle);
             String userIdentity = session.getUser();
-            List<ColumnMetadata> columnsMetadata = runtime.getColumnMetadata(
-                    userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
+            LanceSchema lanceSchema = runtime.getLanceSchema(userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
+            Schema arrowSchema = runtime.getSchema(userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
+            List<ColumnMetadata> columnsMetadata = LanceRuntime.getColumnMetadata(lanceSchema, arrowSchema);
             SchemaTableName schemaTableName =
                     new SchemaTableName(lanceTableHandle.getSchemaName(), lanceTableHandle.getTableName());
-            return new ConnectorTableMetadata(schemaTableName, columnsMetadata);
+            Map<String, Object> properties = LanceRuntime.getTableProperties(arrowSchema);
+            return new ConnectorTableMetadata(schemaTableName, columnsMetadata, properties);
         }
         catch (Exception e) {
             log.debug(e, "Failed to get table metadata for %s", lanceTableHandle.getTableName());

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceRuntime.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceRuntime.java
@@ -16,6 +16,7 @@ package io.trino.plugin.lance;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.spi.connector.ColumnHandle;
@@ -23,6 +24,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import jakarta.annotation.PreDestroy;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
@@ -50,12 +52,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.lance.LanceTableProperties.BLOB_COLUMNS;
+import static io.trino.plugin.lance.LanceTableProperties.VECTOR_COLUMNS;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -419,12 +422,37 @@ public class LanceRuntime
         return dataset.getLanceSchema();
     }
 
+    public static Map<String, Object> getTableProperties(Schema arrowSchema)
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        List<String> blobColumns = getBlobColumnsFromSchema(arrowSchema);
+        if (!blobColumns.isEmpty()) {
+            properties.put(BLOB_COLUMNS, String.join(", ", blobColumns));
+        }
+
+        String vectorColumns = arrowSchema.getFields().stream()
+                .filter(field -> field.getType() instanceof ArrowType.FixedSizeList)
+                .map(field -> "%s:%s".formatted(field.getName(), ((ArrowType.FixedSizeList) field.getType()).getListSize()))
+                .collect(Collectors.joining(", "));
+        if (!vectorColumns.isEmpty()) {
+            properties.put(VECTOR_COLUMNS, vectorColumns);
+        }
+
+        // TODO Expose file_format_version properties
+        return properties.buildOrThrow();
+    }
+
     public Map<String, ColumnHandle> getColumnHandles(String userIdentity, String tablePath, Long version,
             Map<String, String> storageOptions)
     {
         LanceSchema lanceSchema = getLanceSchema(userIdentity, tablePath, version, storageOptions);
         Schema arrowSchema = getSchema(userIdentity, tablePath, version, storageOptions);
-        Set<String> blobColumns = getBlobColumnsFromSchema(arrowSchema);
+        return getColumnHandles(lanceSchema, arrowSchema);
+    }
+
+    private static Map<String, ColumnHandle> getColumnHandles(LanceSchema lanceSchema, Schema arrowSchema)
+    {
+        List<String> blobColumns = getBlobColumnsFromSchema(arrowSchema);
 
         Map<String, ColumnHandle> result = new LinkedHashMap<>();
 
@@ -469,7 +497,7 @@ public class LanceRuntime
     {
         LanceSchema lanceSchema = getLanceSchema(userIdentity, tablePath, version, storageOptions);
         Schema arrowSchema = getSchema(userIdentity, tablePath, version, storageOptions);
-        Set<String> blobColumns = getBlobColumnsFromSchema(arrowSchema);
+        List<String> blobColumns = getBlobColumnsFromSchema(arrowSchema);
 
         List<LanceColumnHandle> result = new ArrayList<>();
 
@@ -506,18 +534,25 @@ public class LanceRuntime
         return result;
     }
 
-    private static Set<String> getBlobColumnsFromSchema(Schema schema)
+    private static List<String> getBlobColumnsFromSchema(Schema schema)
     {
         return schema.getFields().stream()
                 .filter(BlobUtils::isBlobArrowField)
                 .map(Field::getName)
-                .collect(Collectors.toSet());
+                .collect(toImmutableList());
     }
 
     public List<ColumnMetadata> getColumnMetadata(String userIdentity, String tablePath, Long version,
             Map<String, String> storageOptions)
     {
-        Map<String, ColumnHandle> columnHandles = getColumnHandles(userIdentity, tablePath, version, storageOptions);
+        LanceSchema lanceSchema = getLanceSchema(userIdentity, tablePath, version, storageOptions);
+        Schema arrowSchema = getSchema(userIdentity, tablePath, version, storageOptions);
+        return getColumnMetadata(lanceSchema, arrowSchema);
+    }
+
+    public static List<ColumnMetadata> getColumnMetadata(LanceSchema lanceSchema, Schema arrowSchema)
+    {
+        Map<String, ColumnHandle> columnHandles = getColumnHandles(lanceSchema, arrowSchema);
         return columnHandles.values().stream()
                 .map(c -> ((LanceColumnHandle) c).getColumnMetadata())
                 .collect(toImmutableList());

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceBlobEncoding.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceBlobEncoding.java
@@ -45,6 +45,9 @@ public class TestLanceBlobEncoding
 
             // Verify table was created
             assertThat(computeScalar("SELECT COUNT(*) FROM " + tableName)).isEqualTo(0L);
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("blob_columns = 'content'");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);
@@ -117,6 +120,9 @@ public class TestLanceBlobEncoding
 
             // Verify table was created
             assertThat(computeScalar("SELECT COUNT(*) FROM " + tableName)).isEqualTo(1L);
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("blob_columns = 'content1, content2'");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceVectorColumns.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceVectorColumns.java
@@ -45,6 +45,9 @@ public class TestLanceVectorColumns
 
             // Verify table was created
             assertThat(computeScalar("SELECT COUNT(*) FROM " + tableName)).isEqualTo(0L);
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("vector_columns = 'embedding:768'");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);
@@ -130,6 +133,9 @@ public class TestLanceVectorColumns
 
             // Verify table was created
             assertThat(computeScalar("SELECT COUNT(*) FROM " + tableName)).isEqualTo(1L);
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("vector_columns = 'embedding1:2, embedding2:3'");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);


### PR DESCRIPTION
`SHOW CREATE TABLE` result doesn't contain any table properties.

This PR exposes `blob_columns` and `vector_columns` table properties. `file_format_version` properties can be handled as a follow-up.