### PR TITLE
chore: update lance dependency to v9.0.0-beta.16

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0-beta.16</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- Bumps `org.lance:lance-core` from `7.0.0` to `9.0.0-beta.16`.
- Confirms the `lance-core` 9.0.0-beta.16 POM keeps `lance-namespace-core` and `lance-namespace-apache-client` at `0.7.7`, so no namespace dependency changes were needed.
- Triggering tag: refs/tags/v9.0.0-beta.16

## Verification
- `make lint` passed.
- `make compile` passed.

Note: Maven Central did not yet have `org.lance:lance-core:9.0.0-beta.16` available from the requested URL during validation, so the tagged Lance Java artifact was built and installed into the runner's local Maven cache from `lance-format/lance` at `refs/tags/v9.0.0-beta.16` before rerunning the checks.
