### PR TITLE
chore: update lance dependency to v9.0.0-beta.18

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>9.0.0-beta.18</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Update `org.lance:lance-core` to `9.0.0-beta.18`.
- Align `lance-namespace-core` and `lance-namespace-apache-client` with the beta.18 Lance Java POM compatibility metadata (`0.7.7`).
- Triggering tag: refs/tags/v9.0.0-beta.18

## Verification
- `make lint`
- `make compile`

Note: Maven Central did not have `org.lance:lance-core:9.0.0-beta.18` published at verification time, so I checked out `lance-format/lance` at `refs/tags/v9.0.0-beta.18` and installed the Java artifact into the runner's local Maven cache before running the checks.
