### PR TITLE
chore: update lance dependency to v9.0.0-beta.20

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>9.0.0-beta.20</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

- update `org.lance:lance-core` from `8.0.0` to `9.0.0-beta.20`
- align `lance-namespace-core` and `lance-namespace-apache-client` with Lance core's compatible `0.7.7` versions
- triggered by [`refs/tags/v9.0.0-beta.20`](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.20)

## Verification

- `make lint`
- `make compile`

Both checks passed using the exact tagged Lance core artifact built locally from `v9.0.0-beta.20` while Maven Central propagation was pending.
