### PR TITLE
chore: update lance dependency to v9.0.0-beta.23

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>9.0.0-beta.23</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

- update `org.lance:lance-core` from `8.0.0` to `9.0.0-beta.23`
- align `lance-namespace-core` and `lance-namespace-apache-client` to `0.7.7`, matching the Lance release POM
- triggered by [`refs/tags/v9.0.0-beta.23`](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.23)

## Verification

- `make lint` — passed
- `make compile` — passed

Maven Central had not yet published `lance-core:9.0.0-beta.23` during verification, so the exact tagged Java artifact was built from the Lance source and installed locally before running the checks.
