### PR TITLE
chore: update lance dependency to v9.1.0-beta.2

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>9.1.0-beta.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

- update `org.lance:lance-core` to `9.1.0-beta.2`
- align `lance-namespace-core` and `lance-namespace-apache-client` with the compatible `0.7.7` versions declared by Lance Core
- triggered by [refs/tags/v9.1.0-beta.2](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.2)

## Verification

- `make lint`
- `make compile`

Maven Central had not yet synchronized the beta artifact during verification, so the exact tagged Lance Java artifact was installed locally from source before both checks were run successfully.
