### PR TITLE
chore: update lance dependency to v9.1.0-beta.6

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>9.1.0-beta.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

- update `org.lance:lance-core` from `8.0.0` to `9.1.0-beta.6`
- retain the existing Lance Namespace dependencies at `0.8.6` because they are newer than the `0.7.7` versions declared by Lance Core
- triggered by [refs/tags/v9.1.0-beta.6](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.6)

## Verification

- `make lint` — passed
- `make compile` — passed

Maven Central had not yet indexed `lance-core:9.1.0-beta.6` during verification, so the artifact was built and installed locally from the exact `v9.1.0-beta.6` tag before running the checks.
