### PR TITLE
Support int8/int16 Arrow types (TINYINT/SMALLINT) in type mapping

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceColumnHandle.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceColumnHandle.java
@@ -42,8 +42,10 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -260,7 +262,15 @@ public record LanceColumnHandle(
             return BOOLEAN;
         }
         else if (type instanceof ArrowType.Int intType) {
-            if (intType.getBitWidth() == 32) {
+            if (intType.getBitWidth() == 8) {
+                // Unsigned int8 (0-255) exceeds TINYINT range, so widen to SMALLINT
+                return intType.getIsSigned() ? TINYINT : SMALLINT;
+            }
+            else if (intType.getBitWidth() == 16) {
+                // Unsigned int16 (0-65535) exceeds SMALLINT range, so widen to INTEGER
+                return intType.getIsSigned() ? SMALLINT : INTEGER;
+            }
+            else if (intType.getBitWidth() == 32) {
                 // Unsigned int32 can exceed Integer.MAX_VALUE, so map to BIGINT
                 return intType.getIsSigned() ? INTEGER : BIGINT;
             }
@@ -353,6 +363,12 @@ public record LanceColumnHandle(
     {
         if (trinoType.equals(BOOLEAN)) {
             return ArrowType.Bool.INSTANCE;
+        }
+        else if (trinoType.equals(TINYINT)) {
+            return new ArrowType.Int(8, true);
+        }
+        else if (trinoType.equals(SMALLINT)) {
+            return new ArrowType.Int(16, true);
         }
         else if (trinoType.equals(INTEGER)) {
             return new ArrowType.Int(32, true);


### PR DESCRIPTION
## Summary

`LanceColumnHandle.toTrinoType(ArrowType)` only maps 32- and 64-bit integers. 8- and 16-bit Arrow ints fall through to `throw new UnsupportedOperationException("Unsupported arrow type: ...")`.

Because `getTableMetadata` maps **every** column up front, a single `int8`/`int16` column anywhere in the schema makes the whole table unreadable — `getColumnHandles` throws, `getTableMetadata` returns `null`, and the engine then fails with:

```
Cannot invoke "...ConnectorTableMetadata.getTableSchema()" because the return value of
"...ConnectorMetadata.getTableMetadata(...)" is null
```

(underlying cause, visible with `io.trino.plugin.lance=DEBUG`):

```
java.lang.UnsupportedOperationException: Unsupported arrow type: Int(8, true)
    at io.trino.plugin.lance.LanceColumnHandle.toTrinoType(LanceColumnHandle.java:311)
    at io.trino.plugin.lance.LanceRuntime.getColumnHandles(LanceRuntime.java:435)
    at io.trino.plugin.lance.LanceMetadata.getTableMetadata(LanceMetadata.java:379)
```

This surfaces with datasets that use small integer columns — e.g. COCO-style computer-vision annotation tables where a per-object `iscrowd` flag is stored as `int8`. `SHOW TABLES` works (directory listing), but `DESCRIBE`/`SELECT` on any such table fails.

## Change

Add `int8 → TINYINT` and `int16 → SMALLINT`, mirroring the existing unsigned-widening rule (`uint32 → BIGINT` from #122): unsigned values that overflow the signed Trino type widen one step (`uint8 → SMALLINT`, `uint16 → INTEGER`). Also add the reverse `TINYINT/SMALLINT → Int(8/16)` in `toArrowType` for symmetry.

```java
if (intType.getBitWidth() == 8) {
    return intType.getIsSigned() ? TINYINT : SMALLINT;
}
else if (intType.getBitWidth() == 16) {
    return intType.getIsSigned() ? SMALLINT : INTEGER;
}
else if (intType.getBitWidth() == 32) { ... }   // unchanged
```

## Testing

Verified against a real Lance dataset (dir namespace on S3-compatible storage) whose schema contains `list<int8>` columns alongside `list<string>`, `list<fixed_size_list<float,4>>`, `list<large_binary>`, `float32`, and `int32`:

- Before: `DESCRIBE` / `SELECT` → `getTableMetadata ... is null`.
- After: table opens; `gt_iscrowd` maps to `array(tinyint)`. `DESCRIBE`, `SELECT count(*)`, and `CROSS JOIN UNNEST(...) GROUP BY` aggregations all succeed.

Happy to add a unit test covering int8/int16 → TINYINT/SMALLINT (both signed and unsigned) if that's preferred for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
