### PR TITLE
chore: update lance dependency to v10.0.0-beta.4

### DIFF
--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>10.0.0-beta.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.8.6</version>
+            <version>0.7.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- update `org.lance:lance-core` to `10.0.0-beta.4`
- align `lance-namespace-core` and `lance-namespace-apache-client` with Lance's compatible `0.7.7` versions

## Verification
- `make lint`
- `make compile`

Triggered by [`refs/tags/v10.0.0-beta.4`](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.4).
