### PR TITLE
fix: emit Substrait names for structs nested inside lists

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/SubstraitExpressionBuilder.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/SubstraitExpressionBuilder.java
@@ -603,18 +603,30 @@ public final class SubstraitExpressionBuilder
 
     /**
      * Recursively adds field names to the NamedStruct builder.
-     * Substrait NamedStruct uses a flattened list of names for all fields
+     * Substrait NamedStruct uses a flattened, depth-first list of names for all fields
      * including nested struct children.
      */
     private static void addFieldNames(NamedStruct.Builder schemaBuilder, String name, io.trino.spi.type.Type type)
     {
         schemaBuilder.addNames(name);
+        addNestedFieldNames(schemaBuilder, type);
+    }
+
+    /**
+     * Adds the names contributed by a type's nested fields, excluding a name for the type itself.
+     * A list contributes no name of its own (the consumer supplies the element name), but struct
+     * fields nested inside it still contribute names, so {@code ARRAY(ROW(a, b))} named {@code col}
+     * must emit {@code col, a, b}.
+     */
+    private static void addNestedFieldNames(NamedStruct.Builder schemaBuilder, io.trino.spi.type.Type type)
+    {
         if (type instanceof RowType rowType) {
-            List<RowType.Field> fields = rowType.getFields();
-            for (RowType.Field field : fields) {
-                String childName = field.getName().orElse("field");
-                addFieldNames(schemaBuilder, childName, field.getType());
+            for (RowType.Field field : rowType.getFields()) {
+                addFieldNames(schemaBuilder, field.getName().orElse("field"), field.getType());
             }
+        }
+        else if (type instanceof ArrayType arrayType) {
+            addNestedFieldNames(schemaBuilder, arrayType.getElementType());
         }
     }
 

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestSubstraitExpressionBuilder.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestSubstraitExpressionBuilder.java
@@ -15,6 +15,9 @@ package io.trino.plugin.lance;
 
 import io.airlift.slice.Slices;
 import io.substrait.expression.Expression;
+import io.substrait.proto.ExtendedExpression;
+import io.substrait.proto.NamedStruct;
+import io.substrait.proto.Type;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
@@ -25,6 +28,7 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
@@ -33,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -484,5 +489,91 @@ public class TestSubstraitExpressionBuilder
 
         assertThat(result.substraitExpressions()).hasSize(1);
         assertThat(result.columnNames()).containsExactly("meta\\.data.a\\.b");
+    }
+
+    // ===== NamedStruct.names / lance field-count invariant =====
+
+    @Test
+    public void testBaseSchemaNamesMatchLanceFieldCount()
+            throws Exception
+    {
+        RowType tagRow = RowType.rowType(RowType.field("tag", VARCHAR));
+        RowType abRow = RowType.rowType(RowType.field("a", BIGINT), RowType.field("b", VARCHAR));
+
+        List<LanceColumnHandle> columns = List.of(
+                new LanceColumnHandle("id", INTEGER, true, 0),
+                new LanceColumnHandle("row_col", abRow, true, 1),
+                new LanceColumnHandle("nested_row", RowType.rowType(
+                        RowType.field("x", BIGINT),
+                        RowType.field("inner", tagRow)), true, 2),
+                new LanceColumnHandle("prim_array", new ArrayType(BIGINT), true, 3),
+                new LanceColumnHandle("array_of_row", new ArrayType(tagRow), true, 4),
+                new LanceColumnHandle("array_of_row2", new ArrayType(abRow), true, 5),
+                new LanceColumnHandle("array_of_array_of_row", new ArrayType(new ArrayType(abRow)), true, 6),
+                new LanceColumnHandle("row_with_array", RowType.rowType(
+                        RowType.field("x", BIGINT),
+                        RowType.field("arr", new ArrayType(abRow))), true, 7));
+
+        NamedStruct schema = baseSchemaFor(columns);
+        List<Type> types = schema.getStruct().getTypesList();
+        assertThat(types).hasSize(columns.size());
+
+        int fieldIndex = 0;
+        for (int i = 0; i < types.size(); i++) {
+            assertThat(fieldIndex).isLessThan(schema.getNamesCount());
+            assertThat(schema.getNames(fieldIndex)).isEqualTo(columns.get(i).name());
+            fieldIndex += countFields(types.get(i));
+        }
+        assertThat(fieldIndex).isEqualTo(schema.getNamesCount());
+    }
+
+    @Test
+    public void testBaseSchemaNamesOrderForArrayOfRow()
+            throws Exception
+    {
+        List<LanceColumnHandle> columns = List.of(
+                new LanceColumnHandle("id", INTEGER, true, 0),
+                new LanceColumnHandle("col", new ArrayType(RowType.rowType(
+                        RowType.field("a", BIGINT),
+                        RowType.field("b", VARCHAR))), true, 1));
+
+        NamedStruct schema = baseSchemaFor(columns);
+        List<String> names = new ArrayList<>();
+        for (int i = 0; i < schema.getNamesCount(); i++) {
+            names.add(schema.getNames(i));
+        }
+        assertThat(names).containsExactly("id", "col", "a", "b");
+    }
+
+    /**
+     * Mirror of count_fields() in lance-datafusion/src/substrait.rs: a struct consumes a name for
+     * itself plus one per nested field, a list consumes none of its own, everything else consumes one.
+     */
+    private static int countFields(Type substraitType)
+    {
+        return switch (substraitType.getKindCase()) {
+            case STRUCT -> substraitType.getStruct().getTypesList().stream()
+                    .mapToInt(TestSubstraitExpressionBuilder::countFields)
+                    .sum() + 1;
+            case LIST -> countFields(substraitType.getList().getType());
+            default -> 1;
+        };
+    }
+
+    /**
+     * Builds the base schema the connector would send to lance for a filter on the first column.
+     * The predicate itself is irrelevant: the base schema always covers every column of the table.
+     */
+    private static NamedStruct baseSchemaFor(List<LanceColumnHandle> columns)
+            throws Exception
+    {
+        Map<String, Integer> ordinals = new HashMap<>();
+        for (int i = 0; i < columns.size(); i++) {
+            ordinals.put(columns.get(i).name(), i);
+        }
+        TupleDomain<LanceColumnHandle> domain = TupleDomain.withColumnDomains(
+                Map.of(columns.getFirst(), Domain.singleValue(INTEGER, 42L)));
+        ByteBuffer buffer = SubstraitExpressionBuilder.tupleDomainToSubstrait(domain, columns, ordinals).orElseThrow();
+        return ExtendedExpression.parseFrom(buffer.array()).getBaseSchema();
     }
 }


### PR DESCRIPTION
# Changes

### What was wrong

When Trino pushes a filter down to Lance, it sends along a description of the table. That description has two parts: the column types, which are nested and structured, and the column names, which are just one long flat list. Both sides have to agree on how many names each column uses up.

Current code walked into structs when writing out that name list, but it never walked into arrays. So a column like ARRAY(ROW(tag)) wrote one name, when Lance expected two - one for the column, one for the tag inside it.

That one missing name throws off everything after it. Lance reads the list by counting as it goes, so once a column comes up short, every name it reads after that belongs to the wrong column. Keep going and it eventually asks for a name past the end of the list. That's a crash in the Rust code, and because of how it's called from Java, it doesn't turn into an error message - it takes the whole worker process down with it.

### Fix

In this commit, name-writing is split into two pieces: one that writes the name for the column itself, and one that writes the names for anything nested inside it. The second one now steps into arrays as well as structs. An array doesn't get a name of its own - Lance supplies that - but the struct fields inside it do.

## To reproduce
```
import lance, pyarrow as pa

schema = pa.schema([
    ("id",    pa.int64()),
    ("tags",  pa.list_(pa.struct([("tag", pa.string())]))),   # ARRAY(ROW(tag VARCHAR))
    ("extra", pa.int64()),                                     # must come AFTER tags
])
lance.write_dataset(pa.table({
    "id":    [1, 2, 3],
    "tags":  [[{"tag": "a"}], [{"tag": "b"}], []],
    "extra": [10, 20, 30],
}, schema=schema), "/tmp/lancedata/crash_repro.lance")
```
In trino - 
```
SELECT id FROM lance.default.crash_repro WHERE id = 1;
```
## Stack trace in trino worker node - 
```
  thread '<unnamed>' (1933) panicked at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:225:5:         
  panic in a function that cannot unwind                                                                                             
  stack backtrace:                                                                                                                   
     0:     0x7f2a616ab63e - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as                                         
  core::fmt::Display>::fmt::h93773fc827e3113d                                                                                        
     1:     0x7f2a5bbe49ea - core::fmt::write::hed7b5c73d82ecb7c                                                                     
     2:     0x7f2a616aaa05 - std::io::Write::write_fmt::h6f0185aecf0ed75f                                                            
     3:     0x7f2a616aa698 - std::panicking::panic_with_hook::hb4bd9ac1123582a0                                                      
     4:     0x7f2a616d3438 - std::panicking::panic_handler::{{closure}}::hde00dd15f5637fe2                                           
     5:     0x7f2a616d33b9 - std::sys::backtrace::__rust_end_short_backtrace::hb72197fa777c1785                                      
     6:     0x7f2a616d33ae - __rustc[4425a7e20b4c8619]::rust_begin_unwind                                                            
     7:     0x7f2a5bbf2e9c - core::panicking::panic_nounwind_fmt::h0fb754c2e2cbb5f3                                                  
     8:     0x7f2a5bbf2e6e - core::panicking::panic_nounwind::h8e1b8f50cfcb7944                                                      
     9:     0x7f2a5bbf2eac - core::panicking::panic_cannot_unwind::h8e14f223f3c2508e                                                 
    10:     0x7f2a5a2a2ded - Java_org_lance_ipc_LanceScanner_openStream                                                              
    11:     0x7f6ef840ccd2 - <unknown>                                                                                               
  thread caused non-unwinding panic. aborting.  
```
After fix - 
```
trino:default> SELECT id FROM testlance.<schema>.lance_substrait_repro WHERE id = 1;
 id
----
  1
```