### PR TITLE
fix: keep filtered count(*) off the manifest fast path

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -47,7 +47,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.expression.ConnectorExpression;
-import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.predicate.Domain;
@@ -660,27 +659,12 @@ public class LanceMetadata
 
     private boolean isRowCountAggregate(AggregateFunction aggregate)
     {
-        if (!"count".equalsIgnoreCase(aggregate.getFunctionName())) {
-            return false;
-        }
-        // Only a plain row count maps to the manifest total. Bail out if the aggregation is DISTINCT,
-        // has a FILTER (WHERE ...) clause, or carries in-aggregate sort items (ORDER BY) - none of which
-        // a manifest row count can satisfy.
-        if (aggregate.isDistinct() || !aggregate.getSortItems().isEmpty() || aggregate.getFilter().isPresent()) {
-            return false;
-        }
-        // COUNT(*) takes no argument. COUNT(<non-null constant>) is equivalent because the constant is
-        // never NULL for any row, so it also counts every row. In current Trino, SimplifyCountOverConstant
-        // rewrites COUNT(<non-null constant>) to COUNT(*) before pushdown, so SQL queries reach the
-        // empty-argument case above; this branch is reached only when an argument survives to the SPI
-        // (exercised directly by TestLanceMetadata).
-        List<ConnectorExpression> arguments = aggregate.getArguments();
-        if (arguments.isEmpty()) {
-            return true;
-        }
-        return arguments.size() == 1
-                && arguments.getFirst() instanceof Constant constant
-                && constant.getValue() != null;
+        // Only push plain COUNT(*). Filtered and ordered aggregates are not supported.
+        return "count".equalsIgnoreCase(aggregate.getFunctionName())
+                && aggregate.getArguments().isEmpty()
+                && !aggregate.isDistinct()
+                && aggregate.getFilter().isEmpty()
+                && aggregate.getSortItems().isEmpty();
     }
 
     @Override

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
@@ -217,39 +217,88 @@ public class TestLanceConnectorTest
     }
 
     @Test
-    public void testCountAggregationPushdownBoundaries()
+    public void testCountStarPushdown()
     {
-        // End-to-end checks. Note Trino's SimplifyCountOverConstant rewrites count(<non-null constant>)
-        // to count(*) before pushdown, so these SQL cases reach the connector as count(*) and exercise the
-        // empty-argument path; the constant-argument branch of isRowCountAggregate is covered directly by
-        // TestLanceMetadata. These assertions guard the end-to-end behavior and against optimizer changes.
-        assertQuery("SELECT count(0) FROM region", "SELECT 5");
-        assertExplain("EXPLAIN SELECT count(0) FROM region", "countStar=true");
+        assertCountStar("SELECT count(*) FROM region", "SELECT 5");
+        assertCountStar("SELECT count(0) FROM region", "SELECT 5");
+        assertCountStar("SELECT count(1) FROM region", "SELECT 5");
+        assertCountStar("SELECT count(true) FROM region", "SELECT 5");
+        assertCountStar("SELECT count(false) FROM region", "SELECT 5");
+        assertCountStar("SELECT count('') FROM region", "SELECT 5");
+    }
 
-        assertQuery("SELECT count(0) FROM region WHERE regionkey = 0", "SELECT 1");
-        assertThat((String) computeActual("EXPLAIN SELECT count(0) FROM region WHERE regionkey = 0").getOnlyValue())
-                .doesNotContain("countStar=true");
+    @Test
+    public void testCountStarPushdownEligibility()
+    {
+        assertCountStarNotPushed("SELECT count(NULL) FROM region", "SELECT 0");
+        assertCountStarNotPushed("SELECT count(*) FILTER (WHERE regionkey > 0) FROM region", "SELECT 4");
+        assertCountStarNotPushed("SELECT count(0) FILTER (WHERE regionkey > 0) FROM region", "SELECT 4");
+        assertCountStarNotPushed("SELECT count(*) FROM region WHERE regionkey = 0", "SELECT 1");
+        assertCountStarNotPushed("SELECT count(0) FROM region WHERE regionkey = 0", "SELECT 1");
+        assertCountStarNotPushed("SELECT count(DISTINCT 0) FROM region", "SELECT 1");
+        assertCountStarNotPushed("SELECT count(name) FROM region", "SELECT 5");
+        assertCountStarNotPushed("SELECT count(0) FROM region GROUP BY regionkey", "SELECT 1 FROM region");
+        assertCountStarNotPushed("SELECT count(*), min(regionkey) FROM region", "SELECT 5, 0");
+        assertCountStarNotPushed("SELECT count(*) FROM (SELECT * FROM region LIMIT 2)", "SELECT 2");
+    }
 
-        assertQuery("SELECT count(DISTINCT 0) FROM region", "SELECT 1");
-        assertThat((String) computeActual("EXPLAIN SELECT count(DISTINCT 0) FROM region").getOnlyValue())
-                .doesNotContain("countStar=true");
+    @Test
+    public void testCountStarOnEmptyTable()
+    {
+        String tableName = "test_count_empty_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id BIGINT, name VARCHAR)");
+            assertCountStar("SELECT count(*) FROM " + tableName, "SELECT 0");
+            assertCountStar("SELECT count(0) FROM " + tableName, "SELECT 0");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
 
-        // The original COUNT(*) case must keep taking the fast path after generalizing the predicate.
-        assertQuery("SELECT count(*) FROM region", "SELECT 5");
-        assertExplain("EXPLAIN SELECT count(*) FROM region", "countStar=true");
+    @Test
+    public void testCountStarForVersion()
+    {
+        String tableName = "test_count_version_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT BIGINT '1' AS id", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (BIGINT '2')", 1);
 
-        // A non-numeric constant argument is also a row-count aggregate (again rewritten to count(*) upstream).
-        assertQuery("SELECT count(true) FROM region", "SELECT 5");
-        assertExplain("EXPLAIN SELECT count(true) FROM region", "countStar=true");
+            assertCountStar("SELECT count(*) FROM " + tableName, "SELECT 2");
+            assertCountStar("SELECT count(0) FROM " + tableName, "SELECT 2");
+            assertCountStar("SELECT count(*) FROM " + tableName + " FOR VERSION AS OF 1", "SELECT 1");
+            assertCountStar("SELECT count(0) FROM " + tableName + " FOR VERSION AS OF 1", "SELECT 1");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
 
-        // GROUP BY must stay on the normal path (one count per group, not a single manifest count).
-        assertQuery("SELECT count(0) FROM region GROUP BY regionkey", "SELECT 1 FROM region");
-        assertThat((String) computeActual("EXPLAIN SELECT count(0) FROM region GROUP BY regionkey").getOnlyValue())
-                .doesNotContain("countStar=true");
+    @Test
+    public void testCountStarAfterDelete()
+    {
+        String tableName = "test_count_delete_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM region", 5);
+            assertUpdate("DELETE FROM " + tableName + " WHERE regionkey = 0", 1);
+            assertCountStar("SELECT count(*) FROM " + tableName, "SELECT 4");
+            assertCountStar("SELECT count(0) FROM " + tableName, "SELECT 4");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
 
-        // An aggregate-level FILTER must stay on the normal path.
-        assertQuery("SELECT count(0) FILTER (WHERE regionkey > 0) FROM region", "SELECT 4");
-        assertThat((String) computeActual("EXPLAIN SELECT count(0) FILTER (WHERE regionkey > 0) FROM region").getOnlyValue())
+    private void assertCountStar(String sql, String expected)
+    {
+        assertQuery(sql, expected);
+        assertExplain("EXPLAIN " + sql, "countStar=true");
+    }
+
+    private void assertCountStarNotPushed(String sql, String expected)
+    {
+        assertQuery(sql, expected);
+        assertThat((String) computeActual("EXPLAIN " + sql).getOnlyValue())
                 .doesNotContain("countStar=true");
     }
 

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.io.Resources;
 import io.airlift.json.JsonCodec;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
@@ -40,8 +41,6 @@ import java.util.Optional;
 
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -164,276 +163,48 @@ public class TestLanceMetadata
     }
 
     @Test
-    public void testCountNonNullConstantAggregationPushdown()
+    public void testCountStarPushdownEligibility()
     {
-        AggregateFunction countConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(countConstant),
-                Map.of(),
-                List.of(List.of()));
-
+        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = applyAggregation(TEST_TABLE_1_HANDLE, countStar());
         assertThat(result).isPresent();
-        LanceTableHandle pushedHandle = (LanceTableHandle) result.orElseThrow().getHandle();
-        assertThat(pushedHandle.isCountStar()).isTrue();
+        assertThat(((LanceTableHandle) result.orElseThrow().getHandle()).isCountStar()).isTrue();
+
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE, countStarWithFilter())).isEmpty();
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE, countStarWithOrderBy())).isEmpty();
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE, countDistinct())).isEmpty();
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE, countColumn())).isEmpty();
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE, sumColumn())).isEmpty();
     }
 
     @Test
-    public void testCountNullConstantAggregationNotPushedDown()
+    public void testGroupedCountStarPushdown()
     {
-        AggregateFunction countNullConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(null, INTEGER)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
+        assertThat(applyAggregation(
                 TEST_TABLE_1_HANDLE,
-                List.of(countNullConstant),
-                Map.of(),
-                List.of(List.of())))
+                List.of(List.of(new LanceColumnHandle("x", BIGINT, true, 0))),
+                countStar()))
                 .isEmpty();
     }
 
     @Test
-    public void testFilteredCountConstantAggregationNotPushedDown()
+    public void testCountStarPushdownWithExistingAggregation()
     {
-        AggregateFunction filteredCountConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(),
-                false,
-                Optional.of(Constant.FALSE));
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(filteredCountConstant),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE.withCountStar(), countStar())).isEmpty();
     }
 
     @Test
-    public void testCountConstantAggregationWithTableFilterNotPushedDown()
+    public void testCountStarPushdownWithTableFilter()
     {
-        AggregateFunction countConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
+        assertThat(applyAggregation(
                 TEST_TABLE_1_HANDLE.withSubstraitFilter(new byte[] {1}, List.of("x")),
-                List.of(countConstant),
-                Map.of(),
-                List.of(List.of())))
+                countStar()))
                 .isEmpty();
     }
 
     @Test
-    public void testDistinctCountConstantAggregationNotPushedDown()
+    public void testMultipleAggregatesPushdown()
     {
-        AggregateFunction distinctCountConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(),
-                true,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(distinctCountConstant),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
-    }
-
-    @Test
-    public void testCountColumnAggregationNotPushedDown()
-    {
-        AggregateFunction countColumn = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Variable("x", BIGINT)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(countColumn),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
-    }
-
-    @Test
-    public void testSortedCountConstantAggregationNotPushedDown()
-    {
-        AggregateFunction sortedCountConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(new SortItem("x", ASC_NULLS_LAST)),
-                false,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(sortedCountConstant),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
-    }
-
-    @Test
-    public void testCountStarAggregationPushdown()
-    {
-        AggregateFunction countStar = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(),
-                List.of(),
-                false,
-                Optional.empty());
-
-        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(countStar),
-                Map.of(),
-                List.of(List.of()));
-
-        assertThat(result).isPresent();
-        LanceTableHandle pushedHandle = (LanceTableHandle) result.orElseThrow().getHandle();
-        assertThat(pushedHandle.isCountStar()).isTrue();
-    }
-
-    @Test
-    public void testCountNonNumericConstantAggregationPushdown()
-    {
-        // The fast path is type-agnostic: any non-null constant argument counts every row, so a
-        // non-numeric constant such as count(true) is pushed down just like count(0).
-        AggregateFunction countBooleanConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(true, BOOLEAN)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        Optional<AggregationApplicationResult<ConnectorTableHandle>> result = metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(countBooleanConstant),
-                Map.of(),
-                List.of(List.of()));
-
-        assertThat(result).isPresent();
-        LanceTableHandle pushedHandle = (LanceTableHandle) result.orElseThrow().getHandle();
-        assertThat(pushedHandle.isCountStar()).isTrue();
-    }
-
-    @Test
-    public void testMultipleAggregatesNotPushedDown()
-    {
-        AggregateFunction countConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(countConstant, countConstant),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
-    }
-
-    @Test
-    public void testGroupedCountConstantAggregationNotPushedDown()
-    {
-        AggregateFunction countConstant = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(new Constant(0L, INTEGER)),
-                List.of(),
-                false,
-                Optional.empty());
-        LanceColumnHandle groupColumn = new LanceColumnHandle("x", BIGINT, true, 0);
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(countConstant),
-                Map.of(),
-                List.of(List.of(groupColumn))))
-                .isEmpty();
-    }
-
-    @Test
-    public void testAlreadyPushedAggregationNotPushedDown()
-    {
-        AggregateFunction countStar = new AggregateFunction(
-                "count",
-                BIGINT,
-                List.of(),
-                List.of(),
-                false,
-                Optional.empty());
-
-        // A handle that already carries the row-count fast path must not be pushed a second time.
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE.withCountStar(),
-                List.of(countStar),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
-    }
-
-    @Test
-    public void testNonCountAggregationNotPushedDown()
-    {
-        AggregateFunction sum = new AggregateFunction(
-                "sum",
-                BIGINT,
-                List.of(new Variable("x", BIGINT)),
-                List.of(),
-                false,
-                Optional.empty());
-
-        assertThat(metadata.applyAggregation(
-                SESSION,
-                TEST_TABLE_1_HANDLE,
-                List.of(sum),
-                Map.of(),
-                List.of(List.of())))
-                .isEmpty();
+        assertThat(applyAggregation(TEST_TABLE_1_HANDLE, countStar(), countStar())).isEmpty();
     }
 
     @Test
@@ -456,5 +227,50 @@ public class TestLanceMetadata
                 new SchemaTableName("default", "test_table4"),
                 new SchemaTableName("default", "test_table5"),
                 new SchemaTableName("default", "wide_types_table")));
+    }
+
+    private Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
+            ConnectorTableHandle table,
+            AggregateFunction... aggregates)
+    {
+        return applyAggregation(table, List.of(List.of()), aggregates);
+    }
+
+    private Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
+            ConnectorTableHandle table,
+            List<List<ColumnHandle>> groupingSets,
+            AggregateFunction... aggregates)
+    {
+        return metadata.applyAggregation(SESSION, table, List.of(aggregates), Map.of(), groupingSets);
+    }
+
+    private static AggregateFunction countStar()
+    {
+        return new AggregateFunction("count", BIGINT, List.of(), List.of(), false, Optional.empty());
+    }
+
+    private static AggregateFunction countStarWithFilter()
+    {
+        return new AggregateFunction("count", BIGINT, List.of(), List.of(), false, Optional.of(Constant.FALSE));
+    }
+
+    private static AggregateFunction countStarWithOrderBy()
+    {
+        return new AggregateFunction("count", BIGINT, List.of(), List.of(new SortItem("x", ASC_NULLS_LAST)), false, Optional.empty());
+    }
+
+    private static AggregateFunction countDistinct()
+    {
+        return new AggregateFunction("count", BIGINT, List.of(new Variable("x", BIGINT)), List.of(), true, Optional.empty());
+    }
+
+    private static AggregateFunction countColumn()
+    {
+        return new AggregateFunction("count", BIGINT, List.of(new Variable("x", BIGINT)), List.of(), false, Optional.empty());
+    }
+
+    private static AggregateFunction sumColumn()
+    {
+        return new AggregateFunction("sum", BIGINT, List.of(new Variable("x", BIGINT)), List.of(), false, Optional.empty());
     }
 }


### PR DESCRIPTION
This PR is a follow up to #155 that accounts for more of the count push down arguments: 
- Require empty `FILTER` and `ORDER BY` before pushing `count(*)` onto the existing `countStar` path. A filtered count previously matched empty-arg `count` and would return the manifest total.
- Keep `count(0)`, `count(1)`, and other non-null constants on that path through Trino's `SimplifyCountOverConstant` rewrite. The connector still matches empty-arg `count` only.
- Cover empty tables, time travel, deletes, LIMIT subqueries, and the SQL/SPI eligibility matrix.

Related to #142. `count(*)` already used the manifest fast path. This stops filtered counts from taking it.

## Testing
- `git diff --check`
- `make lint`
- `./mvnw test -pl plugin/trino-lance -Dtest=TestLanceMetadata,TestLanceConnectorTest#testCountStarPushdown+testCountStarPushdownEligibility+testCountStarOnEmptyTable+testCountStarForVersion+testCountStarAfterDelete -Dair.check.skip-enforcer=true -Dsurefire.forkCount=1`