### PR TITLE
chore: watch GitHub Actions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This PR adds dependabot to avoid release warnings. We'll still leave Maven and lance-core to the existing Trino and Lance bump workflows.