### PR TITLE
minor: upgrade to lance-core 10.0.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.3.4"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-(?P<pre_label>alpha|beta|rc)\\.(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{pre_label}.{pre_n}",

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -14,7 +14,7 @@ Each release includes a `trino-lance-<version>-trino<trino_version>.tar.gz` arch
 === "Linux/macOS"
     ```bash
     # Set variables
-    VERSION="0.3.4"
+    VERSION="0.4.0"
     TRINO_VERSION="476"
     PLUGIN_DIR="/usr/lib/trino/plugin"
 
@@ -29,7 +29,7 @@ Each release includes a `trino-lance-<version>-trino<trino_version>.tar.gz` arch
     FROM trinodb/trino:476
 
     # Download and install Lance connector
-    ARG VERSION=0.3.4
+    ARG VERSION=0.4.0
     ARG TRINO_VERSION=476
 
     RUN curl -fsSL "https://github.com/lancedb/lance-trino/releases/download/v${VERSION}/trino-lance-${VERSION}-trino${TRINO_VERSION}.tar.gz" \

--- a/plugin/trino-lance/pom.xml
+++ b/plugin/trino-lance/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.lance</groupId>
         <artifactId>lance-trino-root</artifactId>
-        <version>0.3.4</version>
+        <version>0.4.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>8.0.0</version>
+            <version>10.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.lance</groupId>
     <artifactId>lance-trino-root</artifactId>
-    <version>0.3.4</version>
+    <version>0.4.0</version>
     <packaging>pom</packaging>
 
     <name>${project.artifactId}</name>


### PR DESCRIPTION
This PR moves lance-core from 8.0.0 to 10.0.0 and bumps the connector to 0.4.0. Namespace stays at 0.8.6.

make compile passed on the 10.0.0 jar. No Java source changes.

## Testing
- `git diff --check`
- `make compile`