### PR TITLE
fix: support Arrow int8 and int16 reads and writes

### DIFF
--- a/docs/src/operations/data-types.md
+++ b/docs/src/operations/data-types.md
@@ -8,6 +8,8 @@ Lance supports a subset of Trino data types. This page documents the supported t
 |------------|------------|-------------|
 | `BIGINT` | Int64 | 64-bit signed integer |
 | `INTEGER` | Int32 | 32-bit signed integer |
+| `SMALLINT` | Int16 | 16-bit signed integer |
+| `TINYINT` | Int8 | 8-bit signed integer |
 | `DOUBLE` | Float64 | 64-bit IEEE 754 floating point |
 | `REAL` | Float32 | 32-bit IEEE 754 floating point |
 | `VARCHAR` | Utf8 | Variable-length Unicode string |
@@ -102,8 +104,6 @@ The following Trino types are **not supported**:
 
 | Type | Alternative |
 |------|-------------|
-| `TINYINT` | Use `INTEGER` or `BIGINT` |
-| `SMALLINT` | Use `INTEGER` or `BIGINT` |
 | `DECIMAL` | Use `DOUBLE` |
 | `CHAR(n)` | Use `VARCHAR` |
 | `TIME` | Store as `VARCHAR` or epoch `BIGINT` |

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceArrowToPageScanner.java
@@ -38,9 +38,13 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TimeMicroVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
 import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VarBinaryVector;
@@ -72,9 +76,11 @@ import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.OFFSET_WIDTH;
@@ -426,10 +432,28 @@ public class LanceArrowToPageScanner
                         writeVectorValues(output, nullChecker,
                                 index -> type.writeLong(output, Integer.toUnsignedLong(uint4Vector.get(index))), offset, length);
                     }
+                    else if (vector instanceof UInt2Vector uint2Vector) {
+                        writeVectorValues(output, nullChecker,
+                                index -> type.writeLong(output, Short.toUnsignedInt((short) uint2Vector.get(index))), offset, length);
+                    }
                     else {
                         writeVectorValues(output, nullChecker, index -> type.writeLong(output, ((IntVector) vector).get(index)),
                                 offset, length);
                     }
+                }
+                else if (type.equals(SMALLINT)) {
+                    if (vector instanceof UInt1Vector uint1Vector) {
+                        writeVectorValues(output, nullChecker,
+                                index -> type.writeLong(output, Byte.toUnsignedInt(uint1Vector.get(index))), offset, length);
+                    }
+                    else {
+                        writeVectorValues(output, nullChecker,
+                                index -> type.writeLong(output, ((SmallIntVector) vector).get(index)), offset, length);
+                    }
+                }
+                else if (type.equals(TINYINT)) {
+                    writeVectorValues(output, nullChecker,
+                            index -> type.writeLong(output, ((TinyIntVector) vector).get(index)), offset, length);
                 }
                 else if (type.equals(DATE)) {
                     writeVectorValues(output, nullChecker,

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceColumnHandle.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceColumnHandle.java
@@ -17,16 +17,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.RowType;
-import io.trino.spi.type.TimestampType;
-import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.VarbinaryType;
-import io.trino.spi.type.VarcharType;
-import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
-import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -42,8 +35,10 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -260,7 +255,15 @@ public record LanceColumnHandle(
             return BOOLEAN;
         }
         else if (type instanceof ArrowType.Int intType) {
-            if (intType.getBitWidth() == 32) {
+            if (intType.getBitWidth() == 8) {
+                // Unsigned int8 (0-255) exceeds TINYINT range, so widen to SMALLINT
+                return intType.getIsSigned() ? TINYINT : SMALLINT;
+            }
+            else if (intType.getBitWidth() == 16) {
+                // Unsigned int16 (0-65535) exceeds SMALLINT range, so widen to INTEGER
+                return intType.getIsSigned() ? SMALLINT : INTEGER;
+            }
+            else if (intType.getBitWidth() == 32) {
                 // Unsigned int32 can exceed Integer.MAX_VALUE, so map to BIGINT
                 return intType.getIsSigned() ? INTEGER : BIGINT;
             }
@@ -343,51 +346,6 @@ public record LanceColumnHandle(
     public static boolean isBlobField(Field field)
     {
         return BlobUtils.isBlobArrowField(field);
-    }
-
-    /**
-     * Convert Trino Type to Arrow ArrowType.
-     * This is the reverse of toTrinoType().
-     */
-    public static ArrowType toArrowType(Type trinoType)
-    {
-        if (trinoType.equals(BOOLEAN)) {
-            return ArrowType.Bool.INSTANCE;
-        }
-        else if (trinoType.equals(INTEGER)) {
-            return new ArrowType.Int(32, true);
-        }
-        else if (trinoType.equals(BIGINT)) {
-            return new ArrowType.Int(64, true);
-        }
-        else if (trinoType.equals(REAL)) {
-            return new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
-        }
-        else if (trinoType.equals(DOUBLE)) {
-            return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
-        }
-        else if (trinoType instanceof VarcharType) {
-            return ArrowType.Utf8.INSTANCE;
-        }
-        else if (trinoType instanceof VarbinaryType) {
-            return ArrowType.Binary.INSTANCE;
-        }
-        else if (trinoType instanceof DateType) {
-            return new ArrowType.Date(DateUnit.DAY);
-        }
-        else if (trinoType instanceof TimestampWithTimeZoneType) {
-            return new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC");
-        }
-        else if (trinoType instanceof TimestampType) {
-            return new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
-        }
-        else if (trinoType instanceof ArrayType) {
-            return ArrowType.List.INSTANCE;
-        }
-        else if (trinoType instanceof RowType) {
-            return ArrowType.Struct.INSTANCE;
-        }
-        throw new UnsupportedOperationException("Unsupported Trino type for Arrow conversion: " + trinoType);
     }
 
     @JsonIgnore

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageSink.java
@@ -18,6 +18,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.type.Type;
 import org.apache.arrow.memory.BufferAllocator;
@@ -131,6 +132,9 @@ public class LancePageSink
 
             Slice slice = wrappedBuffer(jsonCodec.toJsonBytes(commitData));
             return completedFuture(ImmutableList.of(slice));
+        }
+        catch (TrinoException e) {
+            throw e;
         }
         catch (Exception e) {
             log.error(e, "Failed to finish page sink for dataset: %s", datasetUri);

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageToArrowConverter.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LancePageToArrowConverter.java
@@ -35,8 +35,13 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -57,6 +62,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
@@ -64,6 +70,8 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
@@ -91,6 +99,12 @@ public final class LancePageToArrowConverter
     {
         if (trinoType.equals(BOOLEAN)) {
             return ArrowType.Bool.INSTANCE;
+        }
+        else if (trinoType.equals(TINYINT)) {
+            return new ArrowType.Int(8, true);
+        }
+        else if (trinoType.equals(SMALLINT)) {
+            return new ArrowType.Int(16, true);
         }
         else if (trinoType.equals(INTEGER)) {
             return new ArrowType.Int(32, true);
@@ -316,11 +330,32 @@ public final class LancePageToArrowConverter
         if (type.equals(BOOLEAN)) {
             writeBooleanBlock(block, (BitVector) vector, rowCount, offset);
         }
+        else if (type.equals(TINYINT)) {
+            writeTinyintBlock(block, (TinyIntVector) vector, rowCount, offset);
+        }
+        else if (type.equals(SMALLINT)) {
+            if (vector instanceof UInt1Vector uint1Vector) {
+                writeUnsignedInt8Block(block, uint1Vector, rowCount, offset);
+            }
+            else {
+                writeSmallintBlock(block, (SmallIntVector) vector, rowCount, offset);
+            }
+        }
         else if (type.equals(INTEGER)) {
-            writeIntegerBlock(block, (IntVector) vector, rowCount, offset);
+            if (vector instanceof UInt2Vector uint2Vector) {
+                writeUnsignedInt16Block(block, uint2Vector, rowCount, offset);
+            }
+            else {
+                writeIntegerBlock(block, (IntVector) vector, rowCount, offset);
+            }
         }
         else if (type.equals(BIGINT)) {
-            writeBigintBlock(block, (BigIntVector) vector, rowCount, offset);
+            if (vector instanceof UInt4Vector uint4Vector) {
+                writeUnsignedInt32Block(block, uint4Vector, rowCount, offset);
+            }
+            else {
+                writeBigintBlock(block, (BigIntVector) vector, rowCount, offset);
+            }
         }
         else if (type.equals(REAL)) {
             writeRealBlock(block, (Float4Vector) vector, rowCount, offset);
@@ -377,6 +412,68 @@ public final class LancePageToArrowConverter
         vector.setValueCount(offset + rowCount);
     }
 
+    private static void writeTinyintBlock(Block block, TinyIntVector vector, int rowCount, int offset)
+    {
+        for (int i = 0; i < rowCount; i++) {
+            if (block.isNull(i)) {
+                vector.setNull(offset + i);
+            }
+            else {
+                vector.setSafe(offset + i, (byte) TINYINT.getLong(block, i));
+            }
+        }
+        vector.setValueCount(offset + rowCount);
+    }
+
+    private static void writeSmallintBlock(Block block, SmallIntVector vector, int rowCount, int offset)
+    {
+        for (int i = 0; i < rowCount; i++) {
+            if (block.isNull(i)) {
+                vector.setNull(offset + i);
+            }
+            else {
+                vector.setSafe(offset + i, (short) SMALLINT.getLong(block, i));
+            }
+        }
+        vector.setValueCount(offset + rowCount);
+    }
+
+    private static void writeUnsignedInt8Block(Block block, UInt1Vector vector, int rowCount, int offset)
+    {
+        for (int i = 0; i < rowCount; i++) {
+            if (block.isNull(i)) {
+                vector.setNull(offset + i);
+            }
+            else {
+                long value = SMALLINT.getLong(block, i);
+                if (value < 0 || value > 255) {
+                    throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE,
+                            format("Value %s is out of range for unsigned 8-bit integer", value));
+                }
+                vector.setSafe(offset + i, (int) value);
+            }
+        }
+        vector.setValueCount(offset + rowCount);
+    }
+
+    private static void writeUnsignedInt16Block(Block block, UInt2Vector vector, int rowCount, int offset)
+    {
+        for (int i = 0; i < rowCount; i++) {
+            if (block.isNull(i)) {
+                vector.setNull(offset + i);
+            }
+            else {
+                long value = INTEGER.getLong(block, i);
+                if (value < 0 || value > 65535) {
+                    throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE,
+                            format("Value %s is out of range for unsigned 16-bit integer", value));
+                }
+                vector.setSafe(offset + i, (int) value);
+            }
+        }
+        vector.setValueCount(offset + rowCount);
+    }
+
     private static void writeIntegerBlock(Block block, IntVector vector, int rowCount, int offset)
     {
         for (int i = 0; i < rowCount; i++) {
@@ -385,6 +482,24 @@ public final class LancePageToArrowConverter
             }
             else {
                 vector.setSafe(offset + i, (int) INTEGER.getLong(block, i));
+            }
+        }
+        vector.setValueCount(offset + rowCount);
+    }
+
+    private static void writeUnsignedInt32Block(Block block, UInt4Vector vector, int rowCount, int offset)
+    {
+        for (int i = 0; i < rowCount; i++) {
+            if (block.isNull(i)) {
+                vector.setNull(offset + i);
+            }
+            else {
+                long value = BIGINT.getLong(block, i);
+                if (value < 0 || value > 4_294_967_295L) {
+                    throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE,
+                            format("Value %s is out of range for unsigned 32-bit integer", value));
+                }
+                vector.setSafe(offset + i, (int) value);
             }
         }
         vector.setValueCount(offset + rowCount);
@@ -561,29 +676,11 @@ public final class LancePageToArrowConverter
         // This is a simplified implementation - for complex nested types more work is needed
         // Note: We don't call allocateNew() here as the parent vector manages allocation
 
-        if (elementType.equals(INTEGER)) {
-            IntVector intVector = (IntVector) dataVector;
-            for (int i = 0; i < length; i++) {
-                if (arrayBlock.isNull(i)) {
-                    intVector.setNull(offset + i);
-                }
-                else {
-                    intVector.setSafe(offset + i, (int) INTEGER.getLong(arrayBlock, i));
-                }
-            }
-            intVector.setValueCount(offset + length);
-        }
-        else if (elementType.equals(BIGINT)) {
-            BigIntVector bigIntVector = (BigIntVector) dataVector;
-            for (int i = 0; i < length; i++) {
-                if (arrayBlock.isNull(i)) {
-                    bigIntVector.setNull(offset + i);
-                }
-                else {
-                    bigIntVector.setSafe(offset + i, BIGINT.getLong(arrayBlock, i));
-                }
-            }
-            bigIntVector.setValueCount(offset + length);
+        if (elementType.equals(TINYINT) ||
+                elementType.equals(SMALLINT) ||
+                elementType.equals(INTEGER) ||
+                elementType.equals(BIGINT)) {
+            writeBlockToVectorAtOffset(arrayBlock, dataVector, elementType, length, offset);
         }
         else if (elementType.equals(REAL)) {
             Float4Vector floatVector = (Float4Vector) dataVector;

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceConnectorTest.java
@@ -48,6 +48,8 @@ import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ADD_COLUMN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ADD_COLUMN_NOT_NULL_CONSTRAINT;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ADD_COLUMN_WITH_COMMENT;
@@ -808,5 +810,14 @@ public class TestLanceConnectorTest
                 assertThat(BIGINT.getLong(page.getBlock(unsignedIdx), 1)).isEqualTo(3_000_000_000L);
             }
         }
+    }
+
+    @Test
+    public void testToTrinoTypeWithInt8AndInt16()
+    {
+        assertThat(LanceColumnHandle.toTrinoType(new ArrowType.Int(8, true))).isEqualTo(TINYINT);
+        assertThat(LanceColumnHandle.toTrinoType(new ArrowType.Int(8, false))).isEqualTo(SMALLINT);
+        assertThat(LanceColumnHandle.toTrinoType(new ArrowType.Int(16, true))).isEqualTo(SMALLINT);
+        assertThat(LanceColumnHandle.toTrinoType(new ArrowType.Int(16, false))).isEqualTo(INTEGER);
     }
 }

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceInt8Int16PageSource.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceInt8Int16PageSource.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lance;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.type.ArrayType;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lance.Dataset;
+import org.lance.Fragment;
+import org.lance.FragmentMetadata;
+import org.lance.FragmentOperation;
+import org.lance.WriteParams;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLanceInt8Int16PageSource
+{
+    private static final Schema SCHEMA = new Schema(
+            List.of(
+                    Field.nullable("id", new ArrowType.Int(32, true)),
+                    Field.nullable("signed_int8", new ArrowType.Int(8, true)),
+                    Field.nullable("unsigned_int8", new ArrowType.Int(8, false)),
+                    Field.nullable("signed_int16", new ArrowType.Int(16, true)),
+                    Field.nullable("unsigned_int16", new ArrowType.Int(16, false)),
+                    new Field("signed_int8_array", FieldType.nullable(new ArrowType.List()),
+                            List.of(Field.nullable("item", new ArrowType.Int(8, true))))),
+            null);
+
+    @Test
+    public void testReadSignedAndUnsignedInt8AndInt16(@TempDir Path tempDir)
+            throws Exception
+    {
+        String datasetPath = tempDir.resolve("int8_int16_test.lance").toString();
+
+        try (BufferAllocator allocator = new RootAllocator()) {
+            Dataset.create(allocator, datasetPath, SCHEMA, new WriteParams.Builder().build()).close();
+
+            try (VectorSchemaRoot root = VectorSchemaRoot.create(SCHEMA, allocator)) {
+                root.allocateNew();
+                IntVector id = (IntVector) root.getVector("id");
+                TinyIntVector signedInt8 = (TinyIntVector) root.getVector("signed_int8");
+                UInt1Vector unsignedInt8 = (UInt1Vector) root.getVector("unsigned_int8");
+                SmallIntVector signedInt16 = (SmallIntVector) root.getVector("signed_int16");
+                UInt2Vector unsignedInt16 = (UInt2Vector) root.getVector("unsigned_int16");
+                ListVector signedInt8Array = (ListVector) root.getVector("signed_int8_array");
+                TinyIntVector items = (TinyIntVector) signedInt8Array.getDataVector();
+
+                id.setSafe(0, 1);
+                signedInt8.setSafe(0, (byte) -128);
+                unsignedInt8.setSafe(0, 255);
+                signedInt16.setSafe(0, (short) -32768);
+                unsignedInt16.setSafe(0, 65535);
+                signedInt8Array.startNewValue(0);
+                items.setSafe(0, (byte) 1);
+                items.setSafe(1, (byte) 0);
+                items.setSafe(2, (byte) -1);
+                signedInt8Array.endValue(0, 3);
+
+                id.setSafe(1, 2);
+                signedInt8.setSafe(1, (byte) 127);
+                unsignedInt8.setSafe(1, 0);
+                signedInt16.setSafe(1, (short) 32767);
+                unsignedInt16.setSafe(1, 0);
+                signedInt8Array.startNewValue(1);
+                items.setSafe(3, (byte) 127);
+                signedInt8Array.endValue(1, 1);
+
+                root.setRowCount(2);
+
+                List<FragmentMetadata> fragments = Fragment.create(
+                        datasetPath, allocator, root, new WriteParams.Builder().build());
+                try (Dataset appended = Dataset.commit(
+                        allocator, datasetPath, new FragmentOperation.Append(fragments), Optional.of(1L))) {
+                    assertThat(appended.countRows()).isEqualTo(2);
+                }
+            }
+
+            LanceRuntime runtime = new LanceRuntime(
+                    new LanceConfig().setSingleLevelNs(true),
+                    ImmutableMap.of("lance.root", tempDir.toString()));
+
+            Map<String, ColumnHandle> columnHandles = runtime.getColumnHandles(null, datasetPath, null, Map.of());
+            assertThat(columnHandles).hasSize(6);
+            assertThat(((LanceColumnHandle) columnHandles.get("signed_int8")).trinoType()).isEqualTo(TINYINT);
+            assertThat(((LanceColumnHandle) columnHandles.get("unsigned_int8")).trinoType()).isEqualTo(SMALLINT);
+            assertThat(((LanceColumnHandle) columnHandles.get("signed_int16")).trinoType()).isEqualTo(SMALLINT);
+            assertThat(((LanceColumnHandle) columnHandles.get("unsigned_int16")).trinoType()).isEqualTo(INTEGER);
+            assertThat(((LanceColumnHandle) columnHandles.get("signed_int8_array")).trinoType()).isEqualTo(new ArrayType(TINYINT));
+
+            LanceTableHandle tableHandle = new LanceTableHandle(
+                    "default", "int8_int16_test", datasetPath, List.of("int8_int16_test"), Map.of());
+            var splitSource = new LanceSplitManager(runtime).getSplits(null, SESSION, tableHandle, null, null);
+            LanceSplit split = (LanceSplit) splitSource.getNextBatch(10).get().getSplits().get(0);
+
+            List<LanceColumnHandle> columns = runtime.getColumnHandleList(null, datasetPath, null, Map.of());
+            try (LanceFragmentPageSource pageSource = new LanceFragmentPageSource(
+                    tableHandle, columns, split.getFragments(), Map.of(), 8192, null, runtime)) {
+                Page page = pageSource.getNextPage();
+                assertThat(page).isNotNull();
+                assertThat(page.getPositionCount()).isEqualTo(2);
+
+                int signedInt8Channel = columnIndex(columns, "signed_int8");
+                int unsignedInt8Channel = columnIndex(columns, "unsigned_int8");
+                int signedInt16Channel = columnIndex(columns, "signed_int16");
+                int unsignedInt16Channel = columnIndex(columns, "unsigned_int16");
+                int signedInt8ArrayChannel = columnIndex(columns, "signed_int8_array");
+
+                assertThat(TINYINT.getLong(page.getBlock(signedInt8Channel), 0)).isEqualTo(-128L);
+                assertThat(TINYINT.getLong(page.getBlock(signedInt8Channel), 1)).isEqualTo(127L);
+                assertThat(SMALLINT.getLong(page.getBlock(unsignedInt8Channel), 0)).isEqualTo(255L);
+                assertThat(SMALLINT.getLong(page.getBlock(unsignedInt8Channel), 1)).isEqualTo(0L);
+                assertThat(SMALLINT.getLong(page.getBlock(signedInt16Channel), 0)).isEqualTo(-32768L);
+                assertThat(SMALLINT.getLong(page.getBlock(signedInt16Channel), 1)).isEqualTo(32767L);
+                assertThat(INTEGER.getLong(page.getBlock(unsignedInt16Channel), 0)).isEqualTo(65535L);
+                assertThat(INTEGER.getLong(page.getBlock(unsignedInt16Channel), 1)).isEqualTo(0L);
+
+                Block signedInt8ArrayRow0 = (Block) new ArrayType(TINYINT).getObject(page.getBlock(signedInt8ArrayChannel), 0);
+                assertThat(signedInt8ArrayRow0.getPositionCount()).isEqualTo(3);
+                assertThat(TINYINT.getLong(signedInt8ArrayRow0, 0)).isEqualTo(1L);
+                assertThat(TINYINT.getLong(signedInt8ArrayRow0, 1)).isEqualTo(0L);
+                assertThat(TINYINT.getLong(signedInt8ArrayRow0, 2)).isEqualTo(-1L);
+
+                Block signedInt8ArrayRow1 = (Block) new ArrayType(TINYINT).getObject(page.getBlock(signedInt8ArrayChannel), 1);
+                assertThat(signedInt8ArrayRow1.getPositionCount()).isEqualTo(1);
+                assertThat(TINYINT.getLong(signedInt8ArrayRow1, 0)).isEqualTo(127L);
+            }
+        }
+    }
+
+    private static int columnIndex(List<LanceColumnHandle> columns, String name)
+    {
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).name().equals(name)) {
+                return i;
+            }
+        }
+        throw new AssertionError("missing column: " + name);
+    }
+}

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceTinyintSmallint.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceTinyintSmallint.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lance;
+
+import io.trino.spi.type.ArrayType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.lance.Dataset;
+import org.lance.ReadOptions;
+import org.lance.WriteParams;
+import org.lance.ipc.LanceScanner;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.trino.plugin.lance.LanceRuntime.TABLE_PATH_SUFFIX;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestLanceTinyintSmallint
+        extends AbstractTestQueryFramework
+{
+    private static final Schema UNSIGNED_INT8_INT16_SCHEMA = new Schema(
+            List.of(
+                    Field.nullable("id", new ArrowType.Int(32, true)),
+                    Field.nullable("unsigned_int8", new ArrowType.Int(8, false)),
+                    Field.nullable("unsigned_int16", new ArrowType.Int(16, false)),
+                    new Field("unsigned_int8_array", FieldType.nullable(new ArrowType.List()),
+                            List.of(Field.nullable("item", new ArrowType.Int(8, false))))),
+            null);
+
+    private Path lanceRoot;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        lanceRoot = Files.createTempDirectory("lance-tinyint-smallint");
+        lanceRoot.toFile().deleteOnExit();
+        return LanceQueryRunner.builder()
+                .addConnectorProperty("lance.root", lanceRoot.toUri().toString())
+                .build();
+    }
+
+    @Test
+    public void testInsertSelectTinyintSmallintAndTinyintArray()
+    {
+        String tableName = "tinyint_smallint_" + System.currentTimeMillis();
+        try {
+            assertUpdate("CREATE TABLE " + tableName +
+                    " (id INTEGER, tinyint_val TINYINT, smallint_val SMALLINT, tinyint_flags ARRAY(TINYINT))");
+            assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                    "(1, TINYINT '-128', SMALLINT '-32768', ARRAY[TINYINT '1', TINYINT '0', TINYINT '-1']), " +
+                    "(2, TINYINT '127', SMALLINT '32767', ARRAY[TINYINT '127'])", 2);
+            var rows = computeActual(
+                    "SELECT id, tinyint_val, smallint_val, tinyint_flags FROM " + tableName + " ORDER BY id")
+                    .getMaterializedRows();
+            assertThat(rows).hasSize(2);
+            assertThat(rows.get(0).getFields()).containsExactly(
+                    1, (byte) -128, (short) -32768, List.of((byte) 1, (byte) 0, (byte) -1));
+            assertThat(rows.get(1).getFields()).containsExactly(
+                    2, (byte) 127, (short) 32767, List.of((byte) 127));
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testInsertIntoUnsignedInt8AndInt16Dataset()
+            throws Exception
+    {
+        String tableName = "unsigned_ints";
+        createUnsignedInt8Int16Dataset(lanceRoot.resolve(tableName + TABLE_PATH_SUFFIX));
+
+        assertThat(computeActual("SELECT unsigned_int8, unsigned_int16, unsigned_int8_array FROM " + tableName).getTypes())
+                .containsExactly(SMALLINT, INTEGER, new ArrayType(SMALLINT));
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                "(1, SMALLINT '200', 65535, ARRAY[SMALLINT '200', SMALLINT '255']), " +
+                "(2, CAST(NULL AS SMALLINT), CAST(NULL AS INTEGER), CAST(NULL AS ARRAY(SMALLINT))), " +
+                "(3, SMALLINT '1', 0, ARRAY[SMALLINT '1', CAST(NULL AS SMALLINT)])", 3);
+
+        assertLanceStoredUnsignedInt8AndInt16(lanceRoot.resolve(tableName + TABLE_PATH_SUFFIX));
+
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (2, SMALLINT '-1', 0, ARRAY[SMALLINT '1'])",
+                ".*out of range for unsigned 8-bit integer.*");
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (3, SMALLINT '256', 0, ARRAY[SMALLINT '1'])",
+                ".*out of range for unsigned 8-bit integer.*");
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (4, SMALLINT '1', -1, ARRAY[SMALLINT '1'])",
+                ".*out of range for unsigned 16-bit integer.*");
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (5, SMALLINT '1', 65536, ARRAY[SMALLINT '1'])",
+                ".*out of range for unsigned 16-bit integer.*");
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (6, SMALLINT '1', 0, ARRAY[SMALLINT '256'])",
+                ".*out of range for unsigned 8-bit integer.*");
+    }
+
+    @Test
+    public void testTinyintAndSmallintCtasPredicates()
+    {
+        assertCtasPredicates("tinyint", "37", "127");
+        assertCtasPredicates("smallint", "32123", "32767");
+    }
+
+    private void assertCtasPredicates(String trinoTypeName, String sampleValueLiteral, String highValueLiteral)
+    {
+        String tableName = "data_mapping_" + trinoTypeName + "_" + System.currentTimeMillis();
+        assertUpdate("CREATE TABLE " + tableName + " AS " +
+                "SELECT CAST(row_id AS varchar(50)) row_id, CAST(value AS " + trinoTypeName + ") value, CAST(value AS " + trinoTypeName + ") another_column " +
+                "FROM (VALUES " +
+                "  ('null value', NULL), " +
+                "  ('sample value', " + sampleValueLiteral + "), " +
+                "  ('high value', " + highValueLiteral + ")) " +
+                " t(row_id, value)", 3);
+        try {
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE rand() = 42 OR value IS NULL", "VALUES 'null value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE rand() = 42 OR value IS NOT NULL", "VALUES 'sample value', 'high value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE rand() = 42 OR value = " + sampleValueLiteral, "VALUES 'sample value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE rand() = 42 OR value = " + highValueLiteral, "VALUES 'high value'");
+
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NULL", "VALUES 'null value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NOT NULL", "VALUES 'sample value', 'high value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value = " + sampleValueLiteral, "VALUES 'sample value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value != " + sampleValueLiteral, "VALUES 'high value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value <= " + sampleValueLiteral, "VALUES 'sample value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value > " + sampleValueLiteral, "VALUES 'high value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value <= " + highValueLiteral, "VALUES 'sample value', 'high value'");
+
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NULL OR value = " + sampleValueLiteral, "VALUES 'null value', 'sample value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NULL OR value != " + sampleValueLiteral, "VALUES 'null value', 'high value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NULL OR value <= " + sampleValueLiteral, "VALUES 'null value', 'sample value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NULL OR value > " + sampleValueLiteral, "VALUES 'null value', 'high value'");
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value IS NULL OR value <= " + highValueLiteral, "VALUES 'null value', 'sample value', 'high value'");
+
+            assertQuery("SELECT row_id FROM " + tableName + " WHERE value = " + sampleValueLiteral + " OR another_column = " + sampleValueLiteral, "VALUES 'sample value'");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    private static void createUnsignedInt8Int16Dataset(Path datasetPath)
+    {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            Dataset.create(allocator, datasetPath.toString(), UNSIGNED_INT8_INT16_SCHEMA, new WriteParams.Builder().build())
+                    .close();
+        }
+    }
+
+    private static void assertLanceStoredUnsignedInt8AndInt16(Path datasetPath)
+            throws Exception
+    {
+        try (BufferAllocator allocator = new RootAllocator();
+                Dataset dataset = Dataset.open(allocator, datasetPath.toString(), new ReadOptions.Builder().build());
+                LanceScanner scanner = dataset.newScan();
+                ArrowReader reader = scanner.scanBatches()) {
+            Schema schema = dataset.getSchema();
+            assertThat(schema.findField("unsigned_int8").getType()).isEqualTo(new ArrowType.Int(8, false));
+            assertThat(schema.findField("unsigned_int16").getType()).isEqualTo(new ArrowType.Int(16, false));
+            assertThat(schema.findField("unsigned_int8_array").getType()).isEqualTo(ArrowType.List.INSTANCE);
+            assertThat(schema.findField("unsigned_int8_array").getChildren().get(0).getType()).isEqualTo(new ArrowType.Int(8, false));
+
+            assertThat(reader.loadNextBatch()).isTrue();
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            assertThat(root.getRowCount()).isEqualTo(3);
+            assertThat(root.getVector("unsigned_int8")).isInstanceOf(UInt1Vector.class);
+            assertThat(root.getVector("unsigned_int16")).isInstanceOf(UInt2Vector.class);
+            assertThat(((ListVector) root.getVector("unsigned_int8_array")).getDataVector()).isInstanceOf(UInt1Vector.class);
+
+            IntVector id = (IntVector) root.getVector("id");
+            UInt1Vector unsignedInt8 = (UInt1Vector) root.getVector("unsigned_int8");
+            UInt2Vector unsignedInt16 = (UInt2Vector) root.getVector("unsigned_int16");
+            ListVector unsignedInt8Array = (ListVector) root.getVector("unsigned_int8_array");
+            UInt1Vector items = (UInt1Vector) unsignedInt8Array.getDataVector();
+
+            int valuesRow = rowWithId(id, 1);
+            assertThat(Byte.toUnsignedInt(unsignedInt8.get(valuesRow))).isEqualTo(200);
+            assertThat(Short.toUnsignedInt((short) unsignedInt16.get(valuesRow))).isEqualTo(65535);
+            assertListUnsignedInt8(unsignedInt8Array, items, valuesRow, 200, 255);
+
+            int nullScalarsRow = rowWithId(id, 2);
+            assertThat(unsignedInt8.isNull(nullScalarsRow)).isTrue();
+            assertThat(unsignedInt16.isNull(nullScalarsRow)).isTrue();
+            assertThat(unsignedInt8Array.isNull(nullScalarsRow)).isTrue();
+
+            int nullElementRow = rowWithId(id, 3);
+            assertThat(Byte.toUnsignedInt(unsignedInt8.get(nullElementRow))).isEqualTo(1);
+            assertThat(Short.toUnsignedInt((short) unsignedInt16.get(nullElementRow))).isEqualTo(0);
+            int nullElementStart = unsignedInt8Array.getElementStartIndex(nullElementRow);
+            assertThat(unsignedInt8Array.getElementEndIndex(nullElementRow) - nullElementStart).isEqualTo(2);
+            assertThat(Byte.toUnsignedInt(items.get(nullElementStart))).isEqualTo(1);
+            assertThat(items.isNull(nullElementStart + 1)).isTrue();
+
+            assertThat(reader.loadNextBatch()).isFalse();
+        }
+    }
+
+    private static void assertListUnsignedInt8(ListVector unsignedInt8Array, UInt1Vector items, int row, int first, int second)
+    {
+        assertThat(unsignedInt8Array.isNull(row)).isFalse();
+        int start = unsignedInt8Array.getElementStartIndex(row);
+        assertThat(unsignedInt8Array.getElementEndIndex(row) - start).isEqualTo(2);
+        assertThat(Byte.toUnsignedInt(items.get(start))).isEqualTo(first);
+        assertThat(Byte.toUnsignedInt(items.get(start + 1))).isEqualTo(second);
+    }
+
+    private static int rowWithId(IntVector id, int expected)
+    {
+        for (int i = 0; i < id.getValueCount(); i++) {
+            if (!id.isNull(i) && id.get(i) == expected) {
+                return i;
+            }
+        }
+        throw new AssertionError("missing id " + expected);
+    }
+}

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceUnsignedInt32.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceUnsignedInt32.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lance;
+
+import io.trino.spi.type.ArrayType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.lance.Dataset;
+import org.lance.ReadOptions;
+import org.lance.WriteParams;
+import org.lance.ipc.LanceScanner;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.trino.plugin.lance.LanceRuntime.TABLE_PATH_SUFFIX;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestLanceUnsignedInt32
+        extends AbstractTestQueryFramework
+{
+    private static final Schema UNSIGNED_INT32_SCHEMA = new Schema(
+            List.of(
+                    Field.nullable("id", new ArrowType.Int(32, true)),
+                    Field.nullable("unsigned_int32", new ArrowType.Int(32, false)),
+                    new Field("unsigned_int32_array", FieldType.nullable(new ArrowType.List()),
+                            List.of(Field.nullable("item", new ArrowType.Int(32, false))))),
+            null);
+
+    private Path lanceRoot;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        lanceRoot = Files.createTempDirectory("lance-unsigned-int32");
+        lanceRoot.toFile().deleteOnExit();
+        return LanceQueryRunner.builder()
+                .addConnectorProperty("lance.root", lanceRoot.toUri().toString())
+                .build();
+    }
+
+    @Test
+    public void testInsertIntoUnsignedInt32Dataset()
+            throws Exception
+    {
+        String tableName = "unsigned_int32";
+        Path datasetPath = lanceRoot.resolve(tableName + TABLE_PATH_SUFFIX);
+        try (BufferAllocator allocator = new RootAllocator()) {
+            Dataset.create(
+                    allocator,
+                    datasetPath.toString(),
+                    UNSIGNED_INT32_SCHEMA,
+                    new WriteParams.Builder().build()).close();
+        }
+
+        assertThat(computeActual("SELECT unsigned_int32, unsigned_int32_array FROM " + tableName).getTypes())
+                .containsExactly(BIGINT, new ArrayType(BIGINT));
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                "(1, BIGINT '3000000000', ARRAY[BIGINT '3000000000', BIGINT '4294967295']), " +
+                "(2, CAST(NULL AS BIGINT), CAST(NULL AS ARRAY(BIGINT))), " +
+                "(3, BIGINT '1', ARRAY[BIGINT '1', CAST(NULL AS BIGINT)])", 3);
+
+        assertLanceStoredUnsignedInt32(datasetPath);
+
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (2, BIGINT '-1', ARRAY[BIGINT '1'])",
+                ".*out of range for unsigned 32-bit integer.*");
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (3, BIGINT '4294967296', ARRAY[BIGINT '1'])",
+                ".*out of range for unsigned 32-bit integer.*");
+        assertQueryFails(
+                "INSERT INTO " + tableName + " VALUES (4, BIGINT '1', ARRAY[BIGINT '4294967296'])",
+                ".*out of range for unsigned 32-bit integer.*");
+    }
+
+    private static void assertLanceStoredUnsignedInt32(Path datasetPath)
+            throws Exception
+    {
+        try (BufferAllocator allocator = new RootAllocator();
+                Dataset dataset = Dataset.open(allocator, datasetPath.toString(), new ReadOptions.Builder().build());
+                LanceScanner scanner = dataset.newScan();
+                ArrowReader reader = scanner.scanBatches()) {
+            Schema schema = dataset.getSchema();
+            assertThat(schema.findField("unsigned_int32").getType()).isEqualTo(new ArrowType.Int(32, false));
+            assertThat(schema.findField("unsigned_int32_array").getType()).isEqualTo(ArrowType.List.INSTANCE);
+            assertThat(schema.findField("unsigned_int32_array").getChildren().get(0).getType()).isEqualTo(new ArrowType.Int(32, false));
+
+            assertThat(reader.loadNextBatch()).isTrue();
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            assertThat(root.getRowCount()).isEqualTo(3);
+            assertThat(root.getVector("unsigned_int32")).isInstanceOf(UInt4Vector.class);
+            assertThat(((ListVector) root.getVector("unsigned_int32_array")).getDataVector()).isInstanceOf(UInt4Vector.class);
+
+            IntVector id = (IntVector) root.getVector("id");
+            UInt4Vector unsignedInt32 = (UInt4Vector) root.getVector("unsigned_int32");
+            ListVector unsignedInt32Array = (ListVector) root.getVector("unsigned_int32_array");
+            UInt4Vector items = (UInt4Vector) unsignedInt32Array.getDataVector();
+
+            int valuesRow = rowWithId(id, 1);
+            assertThat(Integer.toUnsignedLong(unsignedInt32.get(valuesRow))).isEqualTo(3_000_000_000L);
+            assertThat(unsignedInt32Array.isNull(valuesRow)).isFalse();
+            int valuesStart = unsignedInt32Array.getElementStartIndex(valuesRow);
+            assertThat(unsignedInt32Array.getElementEndIndex(valuesRow) - valuesStart).isEqualTo(2);
+            assertThat(Integer.toUnsignedLong(items.get(valuesStart))).isEqualTo(3_000_000_000L);
+            assertThat(Integer.toUnsignedLong(items.get(valuesStart + 1))).isEqualTo(4_294_967_295L);
+
+            int nullScalarsRow = rowWithId(id, 2);
+            assertThat(unsignedInt32.isNull(nullScalarsRow)).isTrue();
+            assertThat(unsignedInt32Array.isNull(nullScalarsRow)).isTrue();
+
+            int nullElementRow = rowWithId(id, 3);
+            assertThat(Integer.toUnsignedLong(unsignedInt32.get(nullElementRow))).isEqualTo(1L);
+            int nullElementStart = unsignedInt32Array.getElementStartIndex(nullElementRow);
+            assertThat(unsignedInt32Array.getElementEndIndex(nullElementRow) - nullElementStart).isEqualTo(2);
+            assertThat(Integer.toUnsignedLong(items.get(nullElementStart))).isEqualTo(1L);
+            assertThat(items.isNull(nullElementStart + 1)).isTrue();
+
+            assertThat(reader.loadNextBatch()).isFalse();
+        }
+    }
+
+    private static int rowWithId(IntVector id, int expected)
+    {
+        for (int i = 0; i < id.getValueCount(); i++) {
+            if (!id.isNull(i) && id.get(i) == expected) {
+                return i;
+            }
+        }
+        throw new AssertionError("missing id " + expected);
+    }
+}


### PR DESCRIPTION
This PR maps Arrow int8 and int16 so `DESCRIBE` and `SELECT` work on those tables. A single int8 or int16 column made the table unreadable. toTrinoType rejected the type, and after adding the mapping the scanner still failed with Unhandled type for long.

- Signed int8 and int16 map to TINYINT and SMALLINT. Unsigned widen to SMALLINT and INTEGER the same way uint32 widens to BIGINT.
- LanceArrowToPageScanner reads TinyIntVector, SmallIntVector, UInt1Vector, and UInt2Vector. LancePageToArrowConverter writes using the table's Arrow vector, so existing uint8, uint16, and uint32 columns stay unsigned. Values outside those ranges fail with NUMERIC_VALUE_OUT_OF_RANGE.
- CREATE and INSERT go through LancePageToArrowConverter.

Related to #216, which added the type mappings but not the scanner and write paths.

## Testing
- git diff --check
- ./mvnw test -pl plugin/trino-lance -Dtest='TestLanceConnectorTest,TestLanceConnectorSmokeTest,TestLanceTinyintSmallint,TestLanceUnsignedInt32,TestLanceInt8Int16PageSource' -Dair.check.skip-enforcer=true -Dsurefire.forkCount=1