### PR TITLE
fix: exclude Blob virtual columns from Substrait schema

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -676,13 +676,19 @@ public class LanceMetadata
         TupleDomain<ColumnHandle> summary = constraint.getSummary();
         TupleDomain<LanceColumnHandle> newConstraint = summary.transformKeys(LanceColumnHandle.class::cast);
 
-        // Get all columns from the table for building the full schema
+        // Blob columns expose virtual columns for projection, but those columns do not exist in the
+        // physical schema consumed by the Lance scanner. Including them in the Substrait schema
+        // makes its field count differ from the scanner schema, so only physical columns may be used
+        // to build Substrait field ordinals and the schema embedded in the filter.
         Map<String, String> storageOptions = getEffectiveStorageOptions(lanceTableHandle);
         String userIdentity = session.getUser();
         List<LanceColumnHandle> allColumns = runtime.getColumnHandleList(
                 userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
+        List<LanceColumnHandle> physicalColumns = allColumns.stream()
+                .filter(column -> column.fieldId() >= 0)
+                .toList();
 
-        Map<String, Integer> fieldIdMap = buildPositionalOrdinals(allColumns);
+        Map<String, Integer> fieldIdMap = buildPositionalOrdinals(physicalColumns);
         SubstraitExpressionBuilder.TupleDomainExtractionResult tupleDomainResult =
                 SubstraitExpressionBuilder.extractTupleDomain(newConstraint, fieldIdMap);
 
@@ -705,7 +711,7 @@ public class LanceMetadata
 
         // Combine TupleDomain and pushed expressions
         Optional<ByteBuffer> substraitFilter = SubstraitExpressionBuilder.combineAllExpressionsToSubstrait(
-                tupleDomainResult.expression(), pushedExpressions, allColumns);
+                tupleDomainResult.expression(), pushedExpressions, physicalColumns);
 
         if (substraitFilter.isEmpty()) {
             log.debug("applyFilter: no substrait filter generated, returning empty");

--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -676,16 +676,13 @@ public class LanceMetadata
         TupleDomain<ColumnHandle> summary = constraint.getSummary();
         TupleDomain<LanceColumnHandle> newConstraint = summary.transformKeys(LanceColumnHandle.class::cast);
 
-        // Blob columns expose virtual columns for projection, but those columns do not exist in the
-        // physical schema consumed by the Lance scanner. Including them in the Substrait schema
-        // makes its field count differ from the scanner schema, so only physical columns may be used
-        // to build Substrait field ordinals and the schema embedded in the filter.
+        // Virtual blob columns are Trino only. Substrait has to match the Lance scanner schema.
         Map<String, String> storageOptions = getEffectiveStorageOptions(lanceTableHandle);
         String userIdentity = session.getUser();
         List<LanceColumnHandle> allColumns = runtime.getColumnHandleList(
                 userIdentity, lanceTableHandle.getTablePath(), lanceTableHandle.getDatasetVersion(), storageOptions);
         List<LanceColumnHandle> physicalColumns = allColumns.stream()
-                .filter(column -> column.fieldId() >= 0)
+                .filter(column -> !column.isBlobVirtualColumn())
                 .toList();
 
         Map<String, Integer> fieldIdMap = buildPositionalOrdinals(physicalColumns);

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceBlobEncoding.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceBlobEncoding.java
@@ -88,6 +88,9 @@ public class TestLanceBlobEncoding
             assertQuery(
                     "SELECT id FROM " + tableName + " WHERE id = 1",
                     "SELECT CAST(1 AS BIGINT)");
+            assertExplain(
+                    "EXPLAIN SELECT id FROM " + tableName + " WHERE id = 1",
+                    "constraint.{0,10}(id|ID)");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceBlobEncoding.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceBlobEncoding.java
@@ -72,6 +72,29 @@ public class TestLanceBlobEncoding
     }
 
     @Test
+    public void testFilterPhysicalColumnWithBlobEncoding()
+    {
+        String tableName = "test_blob_physical_filter_" + System.currentTimeMillis();
+        try {
+            assertUpdate(
+                    "CREATE TABLE " + tableName + " " +
+                            "WITH (blob_columns = 'content') AS " +
+                            "SELECT * FROM (VALUES " +
+                            "    (BIGINT '1', X'01'), " +
+                            "    (BIGINT '2', X'02')) " +
+                            "data(id, content)",
+                    2);
+
+            assertQuery(
+                    "SELECT id FROM " + tableName + " WHERE id = 1",
+                    "SELECT CAST(1 AS BIGINT)");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
     public void testInsertIntoBlobColumn()
     {
         String tableName = "test_blob_insert_" + System.currentTimeMillis();


### PR DESCRIPTION
# Fix Blob filter pushdown schema mismatch

## Summary

- exclude Blob virtual columns from the schema and field ordinals serialized with pushed-down Substrait filters
- keep those virtual columns available for projection and for predicates that remain in Trino
- add focused regression coverage for a physical-column filter on a table with a Blob column

Fixes #237.

## Root cause

`LanceRuntime.getColumnHandleList()` returns both physical Lance fields and the virtual columns exposed for each Blob column. The virtual columns have negative field IDs and do not exist in the physical schema consumed by `LanceScanner`.

`LanceMetadata.applyFilter()` previously included both kinds of columns when it built the positional field map and the Substrait schema. As a result, a pushed predicate on an ordinary physical column could still serialize a schema with more fields than the scanner input schema.

The fix filters that list to physical columns (`fieldId >= 0`) only for Substrait field ordinals and schema serialization. It does not change column discovery, projection, or the handling of non-pushable virtual-column predicates.

## Validation

- reproduced the failure with the new regression test before the fix
- the focused Blob regression test passes after the fix
- targeted Blob, metadata, and Substrait tests: 52 passed
- `make lint`: passed
- `./mvnw verify -Dair.check.skip-enforcer=true -Dsurefire.forkCount=4 "-Dtest=!TestLanceS3*"`: 2,305 passed, 0 failures, 0 errors, 764 skipped
  - the six S3/LocalStack test classes were excluded because LocalStack was unavailable in the local validation environment; the repository's GitHub Actions workflow supplies LocalStack for those classes
- standalone Trino 476 smoke test with the packaged plugin:
  - physical-column filters succeeded on tables with one and multiple Blob columns
  - Blob virtual-column projection and filtering continued to work
  - `EXPLAIN` showed the physical-column predicate in the Lance table scan constraint
