### PR TITLE
fix: resolve mixed-case Lance table names from Trino identifiers

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -71,6 +71,7 @@ import org.lance.ReadOptions;
 import org.lance.SourcedTransaction;
 import org.lance.Transaction;
 import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.errors.NamespaceNotFoundException;
 import org.lance.namespace.model.CreateNamespaceRequest;
 import org.lance.namespace.model.DeclareTableRequest;
 import org.lance.namespace.model.DeclareTableResponse;
@@ -83,7 +84,6 @@ import org.lance.namespace.model.DropTableRequest;
 import org.lance.namespace.model.ListNamespacesRequest;
 import org.lance.namespace.model.ListNamespacesResponse;
 import org.lance.namespace.model.ListTablesRequest;
-import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
 import org.lance.operation.Append;
 import org.lance.operation.Overwrite;
@@ -254,23 +254,25 @@ public class LanceMetadata
             throw new TrinoException(NOT_SUPPORTED, "Lance connector does not support start version for time travel");
         }
 
-        String tablePath = getTablePath(session, name);
-        if (tablePath != null) {
-            List<String> tableId = runtime.getTableId(name.getSchemaName(), name.getTableName());
-            Map<String, String> storageOptions = getStorageOptionsForTable(tableId);
-            String userIdentity = session.getUser();
-
-            Long datasetVersion;
-            if (endVersion.isPresent()) {
-                datasetVersion = resolveVersion(session, tablePath, storageOptions, endVersion.get());
-            }
-            else {
-                datasetVersion = runtime.getLatestVersion(userIdentity, tablePath, storageOptions);
-            }
-
-            return new LanceTableHandle(name.getSchemaName(), name.getTableName(), tablePath, tableId, storageOptions, datasetVersion);
+        Optional<ResolvedTable> existingTable = resolveTable(name);
+        if (existingTable.isEmpty()) {
+            return null;
         }
-        return null;
+        ResolvedTable resolvedTable = existingTable.get();
+        String tablePath = resolvedTable.description().getLocation();
+        List<String> tableId = resolvedTable.tableId();
+        Map<String, String> storageOptions = storageOptionsFrom(resolvedTable.description());
+        String userIdentity = session.getUser();
+
+        Long datasetVersion;
+        if (endVersion.isPresent()) {
+            datasetVersion = resolveVersion(session, tablePath, storageOptions, endVersion.get());
+        }
+        else {
+            datasetVersion = runtime.getLatestVersion(userIdentity, tablePath, storageOptions);
+        }
+
+        return new LanceTableHandle(name.getSchemaName(), name.getTableName(), tablePath, tableId, storageOptions, datasetVersion);
     }
 
     private Long resolveVersion(ConnectorSession session, String tablePath,
@@ -397,13 +399,8 @@ public class LanceMetadata
             return Collections.emptyList();
         }
 
-        List<String> namespaceId = runtime.trinoSchemaToLanceNamespace(schema);
-        ListTablesRequest request = new ListTablesRequest();
-        request.setId(namespaceId);
-
-        ListTablesResponse response = getNamespace().listTables(request);
-        Set<String> tables = response.getTables();
-        if (tables == null || tables.isEmpty()) {
+        Set<String> tables = listNamespaceTables(schema);
+        if (tables.isEmpty()) {
             return Collections.emptyList();
         }
         return tables.stream()
@@ -435,19 +432,28 @@ public class LanceMetadata
 
         String schemaName = prefix.getSchema().orElse(LanceRuntime.DEFAULT_SCHEMA);
         String userIdentity = session.getUser();
-        for (SchemaTableName tableName : listTables(session, Optional.of(schemaName))) {
+        Set<String> remoteTables;
+        try {
+            remoteTables = listNamespaceTables(schemaName);
+        }
+        catch (NamespaceNotFoundException e) {
+            return columns.buildOrThrow();
+        }
+
+        for (String remoteTableName : remoteTables) {
+            SchemaTableName tableName = new SchemaTableName(schemaName, remoteTableName);
+            List<String> tableId = runtime.getTableId(schemaName, remoteTableName);
             try {
-                String tablePath = getTablePath(session, tableName);
-                if (tablePath != null) {
-                    List<String> tableId = runtime.getTableId(tableName.getSchemaName(), tableName.getTableName());
-                    Map<String, String> storageOptions = getStorageOptionsForTable(tableId);
-                    // Use null version for listing (always get latest)
-                    List<ColumnMetadata> columnsMetadata = runtime.getColumnMetadata(userIdentity, tablePath, null, storageOptions);
-                    columns.put(tableName, columnsMetadata);
-                }
+                DescribeTableResponse table = getNamespace().describeTable(new DescribeTableRequest().id(tableId));
+                List<ColumnMetadata> columnsMetadata = runtime.getColumnMetadata(
+                        userIdentity,
+                        table.getLocation(),
+                        null,
+                        storageOptionsFrom(table));
+                columns.put(tableName, columnsMetadata);
             }
-            catch (Exception e) {
-                // Table can disappear during listing operation, skip it
+            catch (org.lance.namespace.errors.TableNotFoundException e) {
+                // Table may disappear between list and describe.
             }
         }
         return columns.buildOrThrow();
@@ -849,21 +855,19 @@ public class LanceMetadata
         LancePageToArrowConverter.validateBlobColumns(tableMetadata.getColumns(), blobColumns);
         LancePageToArrowConverter.validateVectorColumns(tableMetadata.getColumns(), vectorColumns);
 
-        List<String> tableId = runtime.getTableId(tableName.getSchemaName(), tableName.getTableName());
-        String existingPath = getTablePath(session, tableName);
-
-        if (existingPath != null) {
+        Optional<ResolvedTable> existingTable = resolveTable(tableName);
+        if (existingTable.isPresent()) {
             if (saveMode == SaveMode.FAIL) {
                 throw new TrinoException(ALREADY_EXISTS, "Table already exists: " + tableName);
             }
             else if (saveMode == SaveMode.IGNORE) {
                 return;
             }
-            // For REPLACE, overwrite with empty dataset
-            Map<String, String> storageOptions = getStorageOptionsForTable(tableId);
+            ResolvedTable resolvedTable = existingTable.get();
+            String existingPath = resolvedTable.description().getLocation();
+            Map<String, String> storageOptions = storageOptionsFrom(resolvedTable.description());
             Schema arrowSchema = LancePageToArrowConverter.toArrowSchema(tableMetadata.getColumns(), blobColumns, vectorColumns);
             String userIdentity = session.getUser();
-            // For write operations, open dataset directly (not cached)
             try (Dataset dataset = runtime.openDatasetDirect(userIdentity, existingPath, null, storageOptions)) {
                 commitOverwrite(dataset, List.of(), arrowSchema, storageOptions);
             }
@@ -872,7 +876,7 @@ public class LanceMetadata
             return;
         }
 
-        // Declare new table via namespace API
+        List<String> tableId = runtime.getTableId(tableName.getSchemaName(), tableName.getTableName());
         DeclareTableRequest declareTableRequest = new DeclareTableRequest()
                 .id(tableId);
         DeclareTableResponse createResponse = getNamespace().declareTable(declareTableRequest);
@@ -908,24 +912,27 @@ public class LanceMetadata
         LancePageToArrowConverter.validateBlobColumns(tableMetadata.getColumns(), blobColumns);
         LancePageToArrowConverter.validateVectorColumns(tableMetadata.getColumns(), vectorColumns);
 
-        List<String> tableId = runtime.getTableId(tableName.getSchemaName(), tableName.getTableName());
-        String existingPath = getTablePath(session, tableName);
+        List<String> tableId;
         String tablePath;
-        boolean tableExisted = existingPath != null;
+        boolean tableExisted;
         Map<String, String> storageOptions;
         String fileFormatVersion = null;
 
-        if (tableExisted) {
+        Optional<ResolvedTable> existingTable = resolveTable(tableName);
+        if (existingTable.isPresent()) {
             if (!replace) {
                 throw new TrinoException(ALREADY_EXISTS, "Table already exists: " + tableName);
             }
-            log.debug("beginCreateTable: replacing existing table at: %s", existingPath);
-            tablePath = existingPath;
-            storageOptions = getStorageOptionsForTable(tableId);
+            ResolvedTable resolvedTable = existingTable.get();
+            tableId = resolvedTable.tableId();
+            tablePath = resolvedTable.description().getLocation();
+            tableExisted = true;
+            storageOptions = storageOptionsFrom(resolvedTable.description());
+            log.debug("beginCreateTable: replacing existing table at: %s", tablePath);
         }
         else {
-            // Use declareTable to reserve the location without creating the actual table.
-            // The table will only be created in finishCreateTable after fragments are written.
+            tableId = runtime.getTableId(tableName.getSchemaName(), tableName.getTableName());
+            tableExisted = false;
             DeclareTableRequest declareRequest = new DeclareTableRequest();
             tableId.forEach(declareRequest::addIdItem);
             DeclareTableResponse declareResponse = getNamespace().declareTable(declareRequest);
@@ -1300,34 +1307,87 @@ public class LanceMetadata
         }
     }
 
-    private String getTablePath(ConnectorSession session, SchemaTableName schemaTableName)
+    private Optional<ResolvedTable> resolveTable(SchemaTableName name)
     {
-        if (runtime.isSingleLevelNs() && !LanceRuntime.DEFAULT_SCHEMA.equals(schemaTableName.getSchemaName())) {
-            return null;
+        if (runtime.isSingleLevelNs() && !LanceRuntime.DEFAULT_SCHEMA.equals(name.getSchemaName())) {
+            return Optional.empty();
         }
 
+        Set<String> listedTables;
         try {
-            List<String> tableId = runtime.getTableId(schemaTableName.getSchemaName(), schemaTableName.getTableName());
-            DescribeTableRequest request = new DescribeTableRequest()
-                    .id(tableId);
-            DescribeTableResponse response = getNamespace().describeTable(request);
-            return response.getLocation();
+            listedTables = listNamespaceTables(name.getSchemaName());
         }
-        catch (Exception e) {
-            log.debug("Failed to describe table %s: %s", schemaTableName, e.getMessage());
-            return null;
+        catch (NamespaceNotFoundException e) {
+            return Optional.empty();
         }
+
+        Optional<String> remoteTableName = matchListedTableName(listedTables, name.getTableName());
+        if (remoteTableName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<String> tableId = runtime.getTableId(name.getSchemaName(), remoteTableName.get());
+        try {
+            DescribeTableResponse response = getNamespace().describeTable(new DescribeTableRequest().id(tableId));
+            return Optional.of(new ResolvedTable(tableId, response));
+        }
+        catch (org.lance.namespace.errors.TableNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Set<String> listNamespaceTables(String schema)
+    {
+        ListTablesRequest request = new ListTablesRequest();
+        request.setId(runtime.trinoSchemaToLanceNamespace(schema));
+        Set<String> tables = getNamespace().listTables(request).getTables();
+        if (tables == null || tables.isEmpty()) {
+            return Set.of();
+        }
+        return tables;
+    }
+
+    @VisibleForTesting
+    static Optional<String> matchListedTableName(Set<String> listedNames, String trinoTableName)
+    {
+        requireNonNull(listedNames, "listedNames is null");
+        requireNonNull(trinoTableName, "trinoTableName is null");
+        List<String> matches = listedNames.stream()
+                .filter(name -> name.equalsIgnoreCase(trinoTableName))
+                .sorted()
+                .toList();
+        if (matches.size() > 1) {
+            throw new TrinoException(NOT_SUPPORTED,
+                    "Multiple Lance tables match " + trinoTableName + ": " + String.join(", ", matches));
+        }
+        if (matches.size() == 1) {
+            return Optional.of(matches.getFirst());
+        }
+        return Optional.empty();
+    }
+
+    private record ResolvedTable(List<String> tableId, DescribeTableResponse description)
+    {
+    }
+
+    private Map<String, String> storageOptionsFrom(DescribeTableResponse response)
+    {
+        Map<String, String> storageOptions = response.getStorageOptions();
+        if (storageOptions != null && !storageOptions.isEmpty()) {
+            return storageOptions;
+        }
+        Map<String, String> nsOptions = runtime.getNamespaceStorageOptions();
+        if (!nsOptions.isEmpty()) {
+            return nsOptions;
+        }
+        return new HashMap<>();
     }
 
     private Map<String, String> getStorageOptionsForTable(List<String> tableId)
     {
         try {
             DescribeTableRequest request = new DescribeTableRequest().id(tableId);
-            DescribeTableResponse response = getNamespace().describeTable(request);
-            Map<String, String> storageOptions = response.getStorageOptions();
-            if (storageOptions != null && !storageOptions.isEmpty()) {
-                return storageOptions;
-            }
+            return storageOptionsFrom(getNamespace().describeTable(request));
         }
         catch (Exception e) {
             log.debug("Failed to get storage options from describeTable for %s: %s", tableId, e.getMessage());

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceIdentifierCase.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceIdentifierCase.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lance;
+
+import io.airlift.json.JsonCodec;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.lance.Dataset;
+import org.lance.ReadOptions;
+import org.lance.WriteParams;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.DeclareTableRequest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.lance.LanceRuntime.TABLE_PATH_SUFFIX;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestLanceIdentifierCase
+        extends AbstractTestQueryFramework
+{
+    private static final String MIXED_CASE_TABLE = "table-main-20260729T170548Z";
+    private static final Schema ID_SCHEMA = new Schema(
+            List.of(Field.nullable("id", new ArrowType.Int(64, true))),
+            null);
+
+    private Path lanceRoot;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        lanceRoot = Files.createTempDirectory("lance-identifier-case");
+        lanceRoot.toFile().deleteOnExit();
+        return LanceQueryRunner.builder()
+                .addConnectorProperty("lance.root", lanceRoot.toUri().toString())
+                .build();
+    }
+
+    @Test
+    public void testShowTablesLowercaseNameIsQueryableForTimestampTable()
+    {
+        createDataset(MIXED_CASE_TABLE);
+
+        String trinoName = MIXED_CASE_TABLE.toLowerCase(ENGLISH);
+        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(trinoName);
+        assertThat(tableHandle(trinoName).getTableId()).isEqualTo(List.of(MIXED_CASE_TABLE));
+        assertThat(computeScalar("SELECT COUNT(*) FROM " + quoted(MIXED_CASE_TABLE))).isEqualTo(0L);
+        assertThat(computeScalar("SELECT COUNT(*) FROM " + quoted(trinoName))).isEqualTo(0L);
+    }
+
+    @Test
+    public void testSelectFooBarUsingLowercaseName()
+    {
+        createDataset("fooBar");
+
+        assertThat(tableHandle("foobar").getTableId()).isEqualTo(List.of("fooBar"));
+        assertThat(computeScalar("SELECT COUNT(*) FROM foobar")).isEqualTo(0L);
+    }
+
+    @Test
+    public void testSelectAllLowercaseRemoteTable()
+    {
+        createDataset("region");
+
+        assertThat(tableHandle("region").getTableId()).isEqualTo(List.of("region"));
+        assertThat(computeScalar("SELECT COUNT(*) FROM region")).isEqualTo(0L);
+    }
+
+    @Test
+    public void testDropTableUsesResolvedRemoteTableId()
+    {
+        String remoteName = "DropCaseTABLE";
+        createDeclaredDataset(remoteName);
+        assertThat(tableHandle(remoteName).getTableId()).isEqualTo(List.of(remoteName));
+
+        assertUpdate("DROP TABLE " + quoted(remoteName.toLowerCase(ENGLISH)));
+
+        assertThat(Files.exists(datasetPath(remoteName))).isFalse();
+        assertThat(tableHandle(remoteName)).isNull();
+    }
+
+    @Test
+    public void testInsertUsesResolvedRemoteTableId()
+    {
+        String remoteName = "InsertCaseTABLE";
+        createDataset(remoteName);
+        assertThat(tableHandle(remoteName).getTableId()).isEqualTo(List.of(remoteName));
+
+        assertUpdate("INSERT INTO " + quoted(remoteName.toLowerCase(ENGLISH)) + " VALUES (BIGINT '1')", 1);
+
+        assertThat(tableHandle(remoteName).getTableId()).isEqualTo(List.of(remoteName));
+        try (BufferAllocator allocator = new RootAllocator();
+                Dataset dataset = Dataset.open(allocator, datasetPath(remoteName).toString(), new ReadOptions.Builder().build())) {
+            assertThat(dataset.countRows()).isEqualTo(1);
+        }
+        assertThat(computeScalar("SELECT id FROM " + quoted(remoteName.toLowerCase(ENGLISH)))).isEqualTo(1L);
+    }
+
+    @Test
+    public void testCreateOrReplaceUsesResolvedRemoteTableId()
+    {
+        String remoteName = "ReplaceCaseTABLE";
+        createDataset(remoteName);
+        assertThat(tableHandle(remoteName).getTableId()).isEqualTo(List.of(remoteName));
+
+        assertUpdate("CREATE OR REPLACE TABLE " + quoted(remoteName.toLowerCase(ENGLISH)) + " AS SELECT BIGINT '42' AS id", 1);
+
+        assertThat(tableHandle(remoteName).getTableId()).isEqualTo(List.of(remoteName));
+        try (BufferAllocator allocator = new RootAllocator();
+                Dataset dataset = Dataset.open(allocator, datasetPath(remoteName).toString(), new ReadOptions.Builder().build())) {
+            assertThat(dataset.countRows()).isEqualTo(1);
+        }
+        assertThat(computeScalar("SELECT id FROM " + quoted(remoteName.toLowerCase(ENGLISH)))).isEqualTo(42L);
+    }
+
+    @Test
+    public void testCreateTableUsesTrinoLowercaseName()
+    {
+        String tableName = "created_lowercase";
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT BIGINT '1' AS id", 1);
+
+        assertThat(tableHandle(tableName).getTableId()).isEqualTo(List.of(tableName));
+        assertThat(Files.exists(datasetPath(tableName))).isTrue();
+        assertThat(computeScalar("SELECT id FROM " + tableName)).isEqualTo(1L);
+    }
+
+    @Test
+    public void testResolvedTableIdIncludesParentPrefixAndSchema()
+            throws Exception
+    {
+        Path root = Files.createTempDirectory("lance-identifier-case-parent");
+        root.toFile().deleteOnExit();
+        LanceConfig config = new LanceConfig()
+                .setSingleLevelNs(false)
+                .setParent("p1$p2");
+        LanceRuntime runtime = new LanceRuntime(config, Map.of("lance.root", root.toUri().toString()));
+        try {
+            LanceNamespace namespace = runtime.getNamespace();
+            createNamespace(namespace, List.of("p1"));
+            createNamespace(namespace, List.of("p1", "p2"));
+            createNamespace(namespace, List.of("p1", "p2", "analytics"));
+
+            String remoteName = "fooBar";
+            String location = namespace.declareTable(
+                    new DeclareTableRequest().id(List.of("p1", "p2", "analytics", remoteName)))
+                    .getLocation();
+            try (BufferAllocator allocator = new RootAllocator()) {
+                Dataset.create(allocator, location, ID_SCHEMA, new WriteParams.Builder().build()).close();
+            }
+
+            LanceMetadata metadata = new LanceMetadata(
+                    runtime,
+                    config,
+                    JsonCodec.jsonCodec(LanceCommitTaskData.class),
+                    JsonCodec.jsonCodec(LanceMergeCommitData.class));
+            LanceTableHandle handle = metadata.getTableHandle(
+                    SESSION,
+                    new SchemaTableName("analytics", "foobar"),
+                    Optional.empty(),
+                    Optional.empty());
+            assertThat(handle.getTableId()).isEqualTo(List.of("p1", "p2", "analytics", remoteName));
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    private LanceTableHandle tableHandle(String name)
+    {
+        LanceRuntime runtime = newRuntime();
+        try {
+            LanceMetadata metadata = new LanceMetadata(
+                    runtime,
+                    new LanceConfig().setSingleLevelNs(true),
+                    JsonCodec.jsonCodec(LanceCommitTaskData.class),
+                    JsonCodec.jsonCodec(LanceMergeCommitData.class));
+            return metadata.getTableHandle(SESSION, new SchemaTableName("default", name), Optional.empty(), Optional.empty());
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    private LanceRuntime newRuntime()
+    {
+        return new LanceRuntime(
+                new LanceConfig().setSingleLevelNs(true),
+                Map.of("lance.root", lanceRoot.toUri().toString()));
+    }
+
+    private void createDataset(String remoteTableName)
+    {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            Dataset.create(allocator, datasetPath(remoteTableName).toString(), ID_SCHEMA, new WriteParams.Builder().build()).close();
+        }
+    }
+
+    private void createDeclaredDataset(String remoteTableName)
+    {
+        LanceRuntime runtime = newRuntime();
+        try {
+            String location = runtime.getNamespace()
+                    .declareTable(new DeclareTableRequest().id(List.of(remoteTableName)))
+                    .getLocation();
+            try (BufferAllocator allocator = new RootAllocator()) {
+                Dataset.create(allocator, location, ID_SCHEMA, new WriteParams.Builder().build()).close();
+            }
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    private Path datasetPath(String remoteTableName)
+    {
+        return lanceRoot.resolve(remoteTableName + TABLE_PATH_SUFFIX);
+    }
+
+    private static String quoted(String name)
+    {
+        return "\"" + name + "\"";
+    }
+
+    private static void createNamespace(LanceNamespace namespace, List<String> namespaceId)
+    {
+        CreateNamespaceRequest request = new CreateNamespaceRequest();
+        request.setId(namespaceId);
+        namespace.createNamespace(request);
+    }
+}

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -227,6 +228,40 @@ public class TestLanceMetadata
                 new SchemaTableName("default", "test_table4"),
                 new SchemaTableName("default", "test_table5"),
                 new SchemaTableName("default", "wide_types_table")));
+    }
+
+    @Test
+    public void testMatchListedTableNameRestoresTimestampCase()
+    {
+        assertThat(LanceMetadata.matchListedTableName(
+                Set.of("table-main-20260729T170548Z"),
+                "table-main-20260729t170548z"))
+                .contains("table-main-20260729T170548Z");
+    }
+
+    @Test
+    public void testMatchListedTableNameRestoresCamelCase()
+    {
+        assertThat(LanceMetadata.matchListedTableName(Set.of("fooBar"), "foobar")).contains("fooBar");
+    }
+
+    @Test
+    public void testMatchListedTableNameKeepsExactMatch()
+    {
+        assertThat(LanceMetadata.matchListedTableName(Set.of("nation"), "nation")).contains("nation");
+    }
+
+    @Test
+    public void testMatchListedTableNameUnknownTableIsEmpty()
+    {
+        assertThat(LanceMetadata.matchListedTableName(Set.of("nation"), "region")).isEmpty();
+    }
+
+    @Test
+    public void testMatchListedTableNameRejectsCaseCollisions()
+    {
+        assertThatThrownBy(() -> LanceMetadata.matchListedTableName(Set.of("Foo", "foo"), "foo"))
+                .hasMessageContaining("Multiple Lance tables match foo");
     }
 
     private Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(


### PR DESCRIPTION
fixes #226. 

This PR makes mixed-case Lance tables reachable after Trino folds identifiers to lowercase.

- `resolveTable()` lists the remote namespace, matches with `equalsIgnoreCase`, and stores the exact Lance table ID on `LanceTableHandle`. Zero matches means the table is missing. Two matches throw `NOT_SUPPORTED`.
- DROP, INSERT, and CREATE OR REPLACE use that ID. A new CREATE builds an ID from Trino's folded name.
- `NamespaceNotFoundException` and Lance `TableNotFoundException` stay not-found. Other list and describe failures propagate.
- `listTableColumns()` lists the namespace once and describes each remote name.

`SchemaTableName` lowercases both schema and table, so `SHOW TABLES` prints the folded name. That name is queryable.

## Testing
- git diff --check
- ./mvnw test -pl plugin/trino-lance -Dtest='TestLanceMetadata,TestLanceIdentifierCase' -Dair.check.skip-enforcer=true -Dsurefire.forkCount=1