### PR TITLE
fix: replace deprecated listTableColumns with streamRelationColumns

### DIFF
--- a/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
+++ b/plugin/trino-lance/src/main/java/io/trino/plugin/lance/LanceMetadata.java
@@ -40,11 +40,11 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.FieldDereference;
@@ -106,6 +106,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,7 +116,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
+import java.util.function.UnaryOperator;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.lance.RowAddress.LANCE_ROW_ADDRESS;
@@ -391,21 +393,10 @@ public class LanceMetadata
     }
 
     @Override
-    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaNameOrNull)
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        String schema = schemaNameOrNull.orElse(LanceRuntime.DEFAULT_SCHEMA);
-
-        if (!schemaExists(schema)) {
-            return Collections.emptyList();
-        }
-
-        Set<String> tables = listNamespaceTables(schema);
-        if (tables.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return tables.stream()
-                .map(tableName -> new SchemaTableName(schema, tableName))
-                .collect(Collectors.toList());
+        Map<String, Set<String>> remoteTableNamesBySchema = listRemoteTableNamesBySchema(session, schemaName);
+        return List.copyOf(toTrinoTableNames(remoteTableNamesBySchema));
     }
 
     @Override
@@ -424,39 +415,84 @@ public class LanceMetadata
     }
 
     @Override
-    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session,
-            SchemaTablePrefix prefix)
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
-        requireNonNull(prefix, "prefix is null");
-        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
+        Map<String, Set<String>> remoteTableNamesBySchema = listRemoteTableNamesBySchema(session, schemaName);
+        Set<SchemaTableName> requestedTables = relationFilter.apply(toTrinoTableNames(remoteTableNamesBySchema));
+        return loadRelationColumns(session, remoteTableNamesBySchema, requestedTables).iterator();
+    }
 
-        String schemaName = prefix.getSchema().orElse(LanceRuntime.DEFAULT_SCHEMA);
-        String userIdentity = session.getUser();
-        Set<String> remoteTables;
-        try {
-            remoteTables = listNamespaceTables(schemaName);
-        }
-        catch (NamespaceNotFoundException e) {
-            return columns.buildOrThrow();
-        }
-
-        for (String remoteTableName : remoteTables) {
-            SchemaTableName tableName = new SchemaTableName(schemaName, remoteTableName);
-            List<String> tableId = runtime.getTableId(schemaName, remoteTableName);
+    private Map<String, Set<String>> listRemoteTableNamesBySchema(ConnectorSession session, Optional<String> schemaName)
+    {
+        List<String> schemaNames = schemaName.map(List::of).orElseGet(() -> listSchemaNames(session));
+        Map<String, Set<String>> remoteTableNamesBySchema = new LinkedHashMap<>();
+        for (String currentSchemaName : schemaNames) {
+            if (runtime.isSingleLevelNs() && !LanceRuntime.DEFAULT_SCHEMA.equals(currentSchemaName)) {
+                continue;
+            }
             try {
-                DescribeTableResponse table = getNamespace().describeTable(new DescribeTableRequest().id(tableId));
-                List<ColumnMetadata> columnsMetadata = runtime.getColumnMetadata(
-                        userIdentity,
-                        table.getLocation(),
-                        null,
-                        storageOptionsFrom(table));
-                columns.put(tableName, columnsMetadata);
+                remoteTableNamesBySchema.put(currentSchemaName, listRemoteTableNames(currentSchemaName));
             }
-            catch (org.lance.namespace.errors.TableNotFoundException e) {
-                // Table may disappear between list and describe.
+            catch (NamespaceNotFoundException e) {
+                // Namespace may disappear between schema list and table list.
             }
         }
-        return columns.buildOrThrow();
+        return remoteTableNamesBySchema;
+    }
+
+    private static Set<SchemaTableName> toTrinoTableNames(Map<String, Set<String>> remoteTableNamesBySchema)
+    {
+        Set<SchemaTableName> tableNames = new HashSet<>();
+        for (Map.Entry<String, Set<String>> schemaEntry : remoteTableNamesBySchema.entrySet()) {
+            for (String remoteTableName : schemaEntry.getValue()) {
+                tableNames.add(new SchemaTableName(schemaEntry.getKey(), remoteTableName));
+            }
+        }
+        return Set.copyOf(tableNames);
+    }
+
+    private List<RelationColumnsMetadata> loadRelationColumns(
+            ConnectorSession session,
+            Map<String, Set<String>> remoteTableNamesBySchema,
+            Set<SchemaTableName> requestedTables)
+    {
+        List<RelationColumnsMetadata> relationColumns = new ArrayList<>();
+        for (SchemaTableName tableName : requestedTables) {
+            Set<String> remoteTableNames = remoteTableNamesBySchema.get(tableName.getSchemaName());
+            if (remoteTableNames == null) {
+                continue;
+            }
+            Optional<String> remoteTableName = resolveRemoteTableName(remoteTableNames, tableName.getTableName());
+            if (remoteTableName.isEmpty()) {
+                continue;
+            }
+            loadRelationColumnsForTable(session, tableName, remoteTableName.get()).ifPresent(relationColumns::add);
+        }
+        return relationColumns;
+    }
+
+    private Optional<RelationColumnsMetadata> loadRelationColumnsForTable(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            String remoteTableName)
+    {
+        List<String> tableId = runtime.getTableId(tableName.getSchemaName(), remoteTableName);
+        try {
+            DescribeTableResponse tableDescription = getNamespace().describeTable(new DescribeTableRequest().id(tableId));
+            List<ColumnMetadata> columns = runtime.getColumnMetadata(
+                    session.getUser(),
+                    tableDescription.getLocation(),
+                    null,
+                    storageOptionsFrom(tableDescription));
+            return Optional.of(RelationColumnsMetadata.forTable(tableName, columns));
+        }
+        catch (org.lance.namespace.errors.TableNotFoundException e) {
+            // Table may disappear between list and describe.
+            return Optional.empty();
+        }
     }
 
     @Override
@@ -1313,15 +1349,15 @@ public class LanceMetadata
             return Optional.empty();
         }
 
-        Set<String> listedTables;
+        Set<String> remoteTableNames;
         try {
-            listedTables = listNamespaceTables(name.getSchemaName());
+            remoteTableNames = listRemoteTableNames(name.getSchemaName());
         }
         catch (NamespaceNotFoundException e) {
             return Optional.empty();
         }
 
-        Optional<String> remoteTableName = matchListedTableName(listedTables, name.getTableName());
+        Optional<String> remoteTableName = resolveRemoteTableName(remoteTableNames, name.getTableName());
         if (remoteTableName.isEmpty()) {
             return Optional.empty();
         }
@@ -1336,7 +1372,7 @@ public class LanceMetadata
         }
     }
 
-    private Set<String> listNamespaceTables(String schema)
+    private Set<String> listRemoteTableNames(String schema)
     {
         ListTablesRequest request = new ListTablesRequest();
         request.setId(runtime.trinoSchemaToLanceNamespace(schema));
@@ -1348,11 +1384,11 @@ public class LanceMetadata
     }
 
     @VisibleForTesting
-    static Optional<String> matchListedTableName(Set<String> listedNames, String trinoTableName)
+    static Optional<String> resolveRemoteTableName(Set<String> remoteTableNames, String trinoTableName)
     {
-        requireNonNull(listedNames, "listedNames is null");
+        requireNonNull(remoteTableNames, "remoteTableNames is null");
         requireNonNull(trinoTableName, "trinoTableName is null");
-        List<String> matches = listedNames.stream()
+        List<String> matches = remoteTableNames.stream()
                 .filter(name -> name.equalsIgnoreCase(trinoTableName))
                 .sorted()
                 .toList();

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceIdentifierCase.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceIdentifierCase.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.lance;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
@@ -188,6 +190,27 @@ public class TestLanceIdentifierCase
                     Optional.empty(),
                     Optional.empty());
             assertThat(handle.getTableId()).isEqualTo(List.of("p1", "p2", "analytics", remoteName));
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    @Test
+    public void testStreamRelationColumnsIncludesMixedCaseRemoteTable()
+    {
+        String remoteName = "StreamCaseTABLE";
+        createDataset(remoteName);
+        LanceRuntime runtime = newRuntime();
+        try {
+            LanceMetadata metadata = new LanceMetadata(
+                    runtime,
+                    new LanceConfig().setSingleLevelNs(true),
+                    JsonCodec.jsonCodec(LanceCommitTaskData.class),
+                    JsonCodec.jsonCodec(LanceMergeCommitData.class));
+            assertThat(ImmutableList.copyOf(metadata.streamRelationColumns(SESSION, Optional.of("default"), names -> names)))
+                    .extracting(RelationColumnsMetadata::name)
+                    .contains(new SchemaTableName("default", remoteName.toLowerCase(ENGLISH)));
         }
         finally {
             runtime.close();

--- a/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
+++ b/plugin/trino-lance/src/test/java/io/trino/plugin/lance/TestLanceMetadata.java
@@ -23,23 +23,37 @@ import io.trino.spi.connector.AggregationApplicationResult;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.Variable;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.lance.Dataset;
+import org.lance.WriteParams;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.DeclareTableRequest;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
+import static io.trino.plugin.lance.LanceRuntime.TABLE_PATH_SUFFIX;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
@@ -231,37 +245,168 @@ public class TestLanceMetadata
     }
 
     @Test
-    public void testMatchListedTableNameRestoresTimestampCase()
+    public void testListTablesEmptySchemaNameListsTablesFromEverySchema()
+            throws Exception
     {
-        assertThat(LanceMetadata.matchListedTableName(
+        Path root = Files.createTempDirectory("lance-list-tables-all-schemas");
+        root.toFile().deleteOnExit();
+        LanceConfig config = new LanceConfig().setSingleLevelNs(false);
+        LanceRuntime runtime = new LanceRuntime(config, Map.of("lance.root", root.toUri().toString()));
+        try {
+            createAnalyticsAndSalesTables(runtime.getNamespace());
+            LanceMetadata metadata = new LanceMetadata(
+                    runtime,
+                    config,
+                    JsonCodec.jsonCodec(LanceCommitTaskData.class),
+                    JsonCodec.jsonCodec(LanceMergeCommitData.class));
+            assertThat(metadata.listTables(SESSION, Optional.empty()))
+                    .containsExactlyInAnyOrder(
+                            new SchemaTableName("analytics", "events"),
+                            new SchemaTableName("sales", "orders"));
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    @Test
+    public void testStreamRelationColumnsListsTablesFromEverySchemaWhenSchemaNameIsEmpty()
+            throws Exception
+    {
+        Path root = Files.createTempDirectory("lance-relation-columns");
+        root.toFile().deleteOnExit();
+        LanceConfig config = new LanceConfig().setSingleLevelNs(false);
+        LanceRuntime runtime = new LanceRuntime(config, Map.of("lance.root", root.toUri().toString()));
+        try {
+            createAnalyticsAndSalesTables(runtime.getNamespace());
+            LanceMetadata metadata = new LanceMetadata(
+                    runtime,
+                    config,
+                    JsonCodec.jsonCodec(LanceCommitTaskData.class),
+                    JsonCodec.jsonCodec(LanceMergeCommitData.class));
+            assertThat(relationColumns(metadata, Optional.empty(), names -> names))
+                    .extracting(RelationColumnsMetadata::name)
+                    .containsExactlyInAnyOrder(
+                            new SchemaTableName("analytics", "events"),
+                            new SchemaTableName("sales", "orders"));
+            assertThat(relationColumns(metadata, Optional.of("analytics"), names -> names))
+                    .extracting(RelationColumnsMetadata::name)
+                    .containsExactly(new SchemaTableName("analytics", "events"));
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    @Test
+    public void testStreamRelationColumnsAppliesRelationFilterBeforeLoadingColumns()
+            throws Exception
+    {
+        Path root = Files.createTempDirectory("lance-relation-filter");
+        root.toFile().deleteOnExit();
+        LanceConfig config = new LanceConfig().setSingleLevelNs(true);
+        LanceRuntime runtime = new LanceRuntime(config, Map.of("lance.root", root.toUri().toString()));
+        try {
+            createDataset(root, "good_table");
+            Files.createDirectories(root.resolve("broken_table" + TABLE_PATH_SUFFIX));
+            Files.writeString(root.resolve("broken_table" + TABLE_PATH_SUFFIX).resolve("not-a-dataset"), "invalid");
+
+            LanceMetadata metadata = new LanceMetadata(
+                    runtime,
+                    config,
+                    JsonCodec.jsonCodec(LanceCommitTaskData.class),
+                    JsonCodec.jsonCodec(LanceMergeCommitData.class));
+            SchemaTableName goodTable = new SchemaTableName("default", "good_table");
+            SchemaTableName brokenTable = new SchemaTableName("default", "broken_table");
+            assertThat(metadata.listTables(SESSION, Optional.of("default"))).contains(goodTable, brokenTable);
+
+            List<RelationColumnsMetadata> relationColumns = relationColumns(
+                    metadata,
+                    Optional.empty(),
+                    names -> {
+                        assertThat(names).contains(goodTable, brokenTable);
+                        return Set.of(goodTable);
+                    });
+            assertThat(relationColumns).extracting(RelationColumnsMetadata::name).containsExactly(goodTable);
+            assertThat(relationColumns.getFirst().tableColumns()).isPresent();
+        }
+        finally {
+            runtime.close();
+        }
+    }
+
+    @Test
+    public void testResolveRemoteTableNameRestoresTimestampCase()
+    {
+        assertThat(LanceMetadata.resolveRemoteTableName(
                 Set.of("table-main-20260729T170548Z"),
                 "table-main-20260729t170548z"))
                 .contains("table-main-20260729T170548Z");
     }
 
     @Test
-    public void testMatchListedTableNameRestoresCamelCase()
+    public void testResolveRemoteTableNameRestoresCamelCase()
     {
-        assertThat(LanceMetadata.matchListedTableName(Set.of("fooBar"), "foobar")).contains("fooBar");
+        assertThat(LanceMetadata.resolveRemoteTableName(Set.of("fooBar"), "foobar")).contains("fooBar");
     }
 
     @Test
-    public void testMatchListedTableNameKeepsExactMatch()
+    public void testResolveRemoteTableNameKeepsExactMatch()
     {
-        assertThat(LanceMetadata.matchListedTableName(Set.of("nation"), "nation")).contains("nation");
+        assertThat(LanceMetadata.resolveRemoteTableName(Set.of("nation"), "nation")).contains("nation");
     }
 
     @Test
-    public void testMatchListedTableNameUnknownTableIsEmpty()
+    public void testResolveRemoteTableNameUnknownTableIsEmpty()
     {
-        assertThat(LanceMetadata.matchListedTableName(Set.of("nation"), "region")).isEmpty();
+        assertThat(LanceMetadata.resolveRemoteTableName(Set.of("nation"), "region")).isEmpty();
     }
 
     @Test
-    public void testMatchListedTableNameRejectsCaseCollisions()
+    public void testResolveRemoteTableNameRejectsCaseCollisions()
     {
-        assertThatThrownBy(() -> LanceMetadata.matchListedTableName(Set.of("Foo", "foo"), "foo"))
+        assertThatThrownBy(() -> LanceMetadata.resolveRemoteTableName(Set.of("Foo", "foo"), "foo"))
                 .hasMessageContaining("Multiple Lance tables match foo");
+    }
+
+    private static List<RelationColumnsMetadata> relationColumns(
+            LanceMetadata metadata,
+            Optional<String> schemaName,
+            UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        return ImmutableList.copyOf(metadata.streamRelationColumns(SESSION, schemaName, relationFilter));
+    }
+
+    private static void createAnalyticsAndSalesTables(LanceNamespace namespace)
+    {
+        createNamespace(namespace, List.of("analytics"));
+        createNamespace(namespace, List.of("sales"));
+        createDeclaredDataset(namespace, List.of("analytics", "events"));
+        createDeclaredDataset(namespace, List.of("sales", "orders"));
+    }
+
+    private static void createNamespace(LanceNamespace namespace, List<String> namespaceId)
+    {
+        CreateNamespaceRequest request = new CreateNamespaceRequest();
+        request.setId(namespaceId);
+        namespace.createNamespace(request);
+    }
+
+    private static void createDeclaredDataset(LanceNamespace namespace, List<String> tableId)
+    {
+        String location = namespace.declareTable(new DeclareTableRequest().id(tableId)).getLocation();
+        Schema schema = new Schema(List.of(Field.nullable("id", new ArrowType.Int(64, true))), null);
+        try (BufferAllocator allocator = new RootAllocator()) {
+            Dataset.create(allocator, location, schema, new WriteParams.Builder().build()).close();
+        }
+    }
+
+    private static void createDataset(Path root, String remoteTableName)
+    {
+        Schema schema = new Schema(List.of(Field.nullable("id", new ArrowType.Int(64, true))), null);
+        try (BufferAllocator allocator = new RootAllocator()) {
+            Dataset.create(allocator, root.resolve(remoteTableName + TABLE_PATH_SUFFIX).toString(), schema, new WriteParams.Builder().build()).close();
+        }
     }
 
     private Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(


### PR DESCRIPTION
This PR overrides `streamRelationColumns` and removes `listTableColumns`. Trino 476 calls the new SPI, where `listTableColumns` is deprecated.

Now we apply `relationFilter` before `describeTable` and `getColumnMetadata`. Also, `listTables` with an empty schema name lists tables from every schema. `streamRelationColumns` uses the same listing helper.

## Testing

- `./mvnw test -pl plugin/trino-lance -Dtest='TestLanceMetadata,TestLanceIdentifierCase' -Dair.check.skip-enforcer=true -Dsurefire.forkCount=1`
