### PR TITLE
ci: skip lance release timer on forks

### DIFF
--- a/.github/workflows/lance-release-timer.yml
+++ b/.github/workflows/lance-release-timer.yml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   trigger-update:
+    if: github.repository == 'lance-format/lance-trino'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pr skips the scheduled release timer on forks, and limits the job to the main repo. 

Kept getting action failures on my fork lol