### PR TITLE
docs: list TIMESTAMP, TINYINT, and SMALLINT as supported

### DIFF
--- a/docs/src/operations/data-types.md
+++ b/docs/src/operations/data-types.md
@@ -15,6 +15,8 @@ Lance supports a subset of Trino data types. This page documents the supported t
 | `VARCHAR` | Utf8 | Variable-length Unicode string |
 | `BOOLEAN` | Boolean | True or false |
 | `DATE` | Date32 | Calendar date (days since epoch) |
+| `TIMESTAMP` | Timestamp[us] | no time zone |
+| `TIMESTAMP WITH TIME ZONE` | Timestamp[us, UTC] | UTC |
 | `VARBINARY` | Binary | Variable-length binary data |
 | `ARRAY<T>` | List | Array of elements of type T |
 
@@ -74,6 +76,19 @@ INSERT INTO lance.default.events VALUES
     (2, DATE '2024-06-30');
 ```
 
+### Timestamp types
+
+```sql
+CREATE TABLE lance.default.events_ts (
+    id BIGINT,
+    created_at TIMESTAMP,
+    created_at_tz TIMESTAMP WITH TIME ZONE
+);
+
+INSERT INTO lance.default.events_ts VALUES
+    (1, TIMESTAMP '2024-01-15 12:00:00', TIMESTAMP '2024-01-15 12:00:00 America/New_York');
+```
+
 ### Binary type
 
 ```sql
@@ -107,7 +122,6 @@ The following Trino types are **not supported**:
 | `DECIMAL` | Use `DOUBLE` |
 | `CHAR(n)` | Use `VARCHAR` |
 | `TIME` | Store as `VARCHAR` or epoch `BIGINT` |
-| `TIMESTAMP` | Store as `DATE` or epoch `BIGINT` |
 | `MAP<K,V>` | Not supported |
 | `ROW(...)` | Not supported for writes |
 

--- a/docs/src/operations/ddl/create-table.md
+++ b/docs/src/operations/ddl/create-table.md
@@ -260,11 +260,15 @@ CREATE TABLE lance.default.ml_data (
 |------|-------------|
 | `BIGINT` | 64-bit signed integer |
 | `INTEGER` | 32-bit signed integer |
+| `SMALLINT` | 16-bit signed integer |
+| `TINYINT` | 8-bit signed integer |
 | `DOUBLE` | 64-bit floating point |
 | `REAL` | 32-bit floating point |
 | `VARCHAR` | Variable-length string |
 | `BOOLEAN` | Boolean (true/false) |
 | `DATE` | Calendar date |
+| `TIMESTAMP` | no time zone |
+| `TIMESTAMP WITH TIME ZONE` | UTC |
 | `VARBINARY` | Variable-length binary |
 | `ARRAY<type>` | Array of elements |
 
@@ -274,7 +278,7 @@ CREATE TABLE lance.default.ml_data (
 - NOT NULL constraints are not supported
 - Default column values are not supported
 - CHAR type is not supported (use VARCHAR)
-- TIME and TIMESTAMP types are not supported
+- TIME is not supported
 - DECIMAL type is not supported (use DOUBLE)
 - MAP and ROW types are not supported for writes
 - Column names cannot contain dots or special characters


### PR DESCRIPTION
This PR updates the type pages to match the connector. `TIMESTAMP` read and write landed in #41. `TINYINT` and `SMALLINT` landed in #236.