### PR TITLE
ci: skip Test on docs-only changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Build docs
         run: make docs-build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Docs
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v8
+
+      - name: Build docs
+        run: make docs-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,17 @@ name: Test
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ product-test-reports
 **/dependency-reduced-pom.xml
 core/trino-web-ui/src/main/resources/webapp/dist/
 .node
+docs/site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,9 @@ make verify    # Full verification
 make run       # Run development server
 make lint      # Run code style checks (checkstyle, modernizer, sortpom)
 make format    # Format pom.xml files
-make check     # Run all checks without tests
+make check      # Run all checks without tests
+make serve-docs # Serve documentation locally
+make docs-build # Build documentation with mkdocs --strict
 ```
 
 ### Installation

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean install compile package help run lint format check serve-docs
+.PHONY: build test clean install compile package help run lint format check serve-docs docs-build
 
 # Compute a safe Surefire forkCount based on system thread limits.
 # Each test fork starts a Trino DistributedQueryRunner that needs ~500 threads.
@@ -24,6 +24,7 @@ help:
 	@echo "  format    - Format pom.xml files"
 	@echo "  check     - Run lint checks without tests"
 	@echo "  serve-docs - Serve documentation locally"
+	@echo "  docs-build - Build documentation with mkdocs --strict"
 
 # Build the project
 build: compile package
@@ -71,3 +72,7 @@ check:
 # Serve documentation locally
 serve-docs:
 	cd docs && uv pip install --system -r requirements.txt && mkdocs serve
+
+# Build documentation and fail on warnings
+docs-build:
+	cd docs && uv run --with-requirements requirements.txt mkdocs build --strict


### PR DESCRIPTION
This PR stops Test from running when the only edits are `docs/**` or `README.md`, same as lance-spark!

Also, doc only changes run `make docs-build` instead, which uses `mkdocs --strict`. Then tests also cancels stale PR runs. `docs/site` is gitignored.

## Testing
- git diff --check
- make docs-build